### PR TITLE
Check for malicious Service Workers persistence in hooks

### DIFF
--- a/extension/Makefile
+++ b/extension/Makefile
@@ -14,7 +14,7 @@ lint:
 	npx eslint . --ignore-pattern "dist/*" --ignore-pattern "hooks/*" --ignore-pattern "pages/*"
 
 package: build
-	zip -r $(ZIP_FILE) manifest.json dist/bundle.js assets hooks icons pages
+	zip -r $(ZIP_FILE) manifest.json dist/bundle.js assets icons pages
 	cp $(ZIP_FILE) ../dist/
 
 cleanup:

--- a/extension/tsconfig.hooks.json
+++ b/extension/tsconfig.hooks.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "types": ["firefox-webext-browser"],
-    "outDir": "./dist",
+    "outDir": "./dist"
   },
   "include": ["./src/webcat/hooks.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
The hooks have been updated to try to address https://github.com/freedomofpress/webcat/issues/18

In practice, at every main frame we will try to update all registered Service Workers, if active. Not sure about the performance impact and if the implementation covers all cases though. 