### PR TITLE
Allow manual trigger of update.json

### DIFF
--- a/.github/workflows/publish-update.json.yml
+++ b/.github/workflows/publish-update.json.yml
@@ -1,6 +1,7 @@
 name: Publish update.json to R2
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Sigh.. and a follow up to https://github.com/freedomofpress/webcat/pull/87 and https://github.com/freedomofpress/webcat/pull/86 : need a way to manually trigger it after all, as the last PR didn't modify update.json.