### PR TITLE
security: fix too strict parsing of relative/absolute redirects https

### DIFF
--- a/extension/src/webcat/validators.ts
+++ b/extension/src/webcat/validators.ts
@@ -389,16 +389,16 @@ export async function validateCSP(
 }
 
 export function isSafeRelativeLocation(value: string): boolean {
-  const trimmed = value.trim();
+  value = value.trim();
 
-  // Reject protocol-relative URLs: "//example.com"
-  if (trimmed.startsWith("//")) return false;
-
-  // Reject ANY absolute URL with a scheme: "https:", "javascript:", "data:", etc.
-  const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
-  if (SCHEME_RE.test(trimmed)) return false;
-
-  return true;
+  // No scheme, no protocol-relative, no backslashes
+  return (
+    (value.startsWith("/") ||
+      value.startsWith("../") ||
+      value.startsWith("./")) &&
+    !value.startsWith("//") &&
+    !value.includes("\\")
+  );
 }
 
 export async function witnessTimestampsFromCosignedTreeHead(


### PR DESCRIPTION
 - Attempt at fixing: https://github.com/freedomofpress/webcat/issues/100
 - Adds tests for some of the violating conditions

I'm still not super happy with this logic and I hope there was something smarter. There's potentially allowed cases that are disallowed (ie: relative backslash paths `..\`), but I preferred not to add too many exceptions. There's also cases when the redirect is an absolute url with a scheme and an origin, but it is the same as the WEBCAT one. I did not want to pass origin information to this function, but we'd have to monitor real world cases and see if there's usages where this can potentially be a significant limitation.