### PR TITLE
security: fix detection of default_src none

### DIFF
--- a/extension/src/webcat/validators.ts
+++ b/extension/src/webcat/validators.ts
@@ -165,10 +165,12 @@ export async function validateCSP(
   // 'self' and 'none' are allowed, but they have different implications and we should tag them
   if (default_src) {
     for (const src of default_src) {
-      if (src === source_keywords.None) {
+      // See https://github.com/freedomofpress/webcat/issues/99
+      if (src === source_keywords.None && default_src.length === 1) {
         default_src_is_none = true;
         break;
-      } else if (src === source_keywords.Self) {
+        // TODO: we can probably be less restrictive here
+      } else if (src === source_keywords.Self || src === source_keywords.None) {
         // Explicitly allowed for readability
         continue;
       } else {

--- a/extension/tests/webcat/validators.test.ts
+++ b/extension/tests/webcat/validators.test.ts
@@ -360,6 +360,23 @@ describe("validateCSP", () => {
       "script-src cannot contain blob: which is unsupported.",
     );
   });
+
+  // See https://github.com/freedomofpress/webcat/issues/99
+  it("should throw when default-src contains 'none' and 'self' and object-src is missing", async () => {
+    const csp = [
+      "default-src 'none' 'self'",
+      "script-src 'self'",
+      "style-src 'self'",
+      // object-src missing
+      "child-src 'self'",
+      "frame-src 'self'",
+      "worker-src 'self'",
+    ].join("; ");
+
+    await expect(validateCSP(csp, trustedFQDN, valid_sources)).rejects.toThrow(
+      "default-src is not none, and object-src is not defined.",
+    );
+  });
 });
 
 describe("validateProtocolAndPort", () => {


### PR DESCRIPTION
Attempts to fix https://github.com/freedomofpress/webcat/issues/99, adding also a regression test.

However, the sandbox logic is weak and should probably be re-architected, possibly after some more formal validation, as suggested in https://github.com/freedomofpress/webcat/issues/83. There's also https://github.com/freedomofpress/webcat/issues/101 which brings additional complexities and constraints to the parsing logic.