### PR TITLE
security: reject commas in CSP

### DIFF
--- a/extension/src/webcat/validators.ts
+++ b/extension/src/webcat/validators.ts
@@ -145,7 +145,7 @@ export async function validateCSP(
     UnsafeInline = "'unsafe-inline'",
     UnsafeEval = "'unsafe-eval'",
     UnsafeHashes = "'unsafe-hashes'",
-    StrictDynamic = "'strict-dynamic",
+    StrictDynamic = "'strict-dynamic'",
   }
 
   enum source_types {
@@ -153,6 +153,11 @@ export async function validateCSP(
     Blob = "blob:",
     Data = "data:",
     EnrolledOrigins = 1,
+  }
+
+  // See https://github.com/freedomofpress/webcat/issues/101
+  if (csp.includes(",")) {
+    throw new Error(`CSP contains a comma: ${csp}`);
   }
 
   // The spec (and thus the parsing function) has to lowercase the directive names

--- a/extension/tests/webcat/validators.test.ts
+++ b/extension/tests/webcat/validators.test.ts
@@ -377,6 +377,30 @@ describe("validateCSP", () => {
       "default-src is not none, and object-src is not defined.",
     );
   });
+
+  // See https://github.com/freedomofpress/webcat/issues/101
+  it("should throw when CSP contains a comma (multiple policies)", async () => {
+    const csp = "script-src 'unsafe-eval', script-src 'self'";
+
+    await expect(validateCSP(csp, trustedFQDN, valid_sources)).rejects.toThrow(
+      "CSP contains a comma",
+    );
+  });
+
+  it("should throw when a valid CSP is followed by a comma and garbage", async () => {
+    const csp =
+      [
+        "default-src 'self'",
+        "script-src 'self'",
+        "style-src 'self'",
+        "object-src 'none'",
+        "worker-src 'self'",
+      ].join("; ") + ", @invalid-policy";
+
+    await expect(validateCSP(csp, trustedFQDN, valid_sources)).rejects.toThrow(
+      "CSP contains a comma",
+    );
+  });
 });
 
 describe("validateProtocolAndPort", () => {


### PR DESCRIPTION
Attempts to fix: https://github.com/freedomofpress/webcat/issues/101

To clarify, multiple CSP shouldn't be an issues, since the browser would compute the intersection and that would generally result in applying the most restrictive. However, since the CSP parser does not account for the commas, as reported by the original researcher, the validation logic of disallowed keywords breaks in the first CSP.

It seems like the usage of commas and multiple CSP this way is not very common, thus it should be safe to reject for now, though as anticipated in the other CSP-related issues, we might want to completely revisit the logic here. 