### PR TITLE
feat: add multiple database backends; fix tbb support

### DIFF
--- a/extension/src/webcat/cache.ts
+++ b/extension/src/webcat/cache.ts
@@ -53,6 +53,13 @@ export class LRUCache<K, V extends Destructible> {
     }
     this.cache.delete(key);
   }
+
+  clear(): void {
+    for (const value of this.cache.values()) {
+      this.callDestructor(value);
+    }
+    this.cache.clear();
+  }
 }
 
 export class LRUSet<T> {
@@ -88,5 +95,9 @@ export class LRUSet<T> {
 
   values(): T[] {
     return Array.from(this.cache.values());
+  }
+
+  clear(): void {
+    this.cache.clear();
   }
 }

--- a/extension/src/webcat/db.ts
+++ b/extension/src/webcat/db.ts
@@ -7,6 +7,13 @@ export interface ListMetadata {
   treeHead: number;
 }
 
+interface WebcatStorageBackend {
+  settingsSet(key: string, value: number | string | bigint): Promise<void>;
+  settingsGet<T>(key: string): Promise<T | null>;
+  replaceList(leaves: readonly (readonly [string, string])[]): Promise<number>;
+  getEnrollmentByFqdn(fqdn: string): Promise<Uint8Array>;
+}
+
 // Settings keys
 const KEY_LAST_CHECKED = "lastChecked";
 const KEY_LAST_UPDATED = "lastUpdated";
@@ -15,14 +22,34 @@ const KEY_LAST_BLOCK_TIME = "lastBlockTime";
 const KEY_LIST_COUNT = "listCount";
 
 export class WebcatDatabase {
-  private dbPromise: Promise<IDBDatabase>;
+  private backendPromise: Promise<WebcatStorageBackend>;
 
   constructor(private readonly name = "webcat") {
-    this.dbPromise = this.openDatabase(this.name);
+    this.backendPromise = this.createStorageBackend(this.name);
   }
 
-  private async ensureDBOpen(): Promise<IDBDatabase> {
-    return this.dbPromise;
+  private async getBackend(): Promise<WebcatStorageBackend> {
+    return this.backendPromise;
+  }
+
+  private async createStorageBackend(
+    name: string,
+  ): Promise<WebcatStorageBackend> {
+    if (typeof indexedDB === "undefined") {
+      console.warn("[webcat] IndexedDB unavailable, using in-memory backend");
+      return new InMemoryStorageBackend();
+    }
+
+    try {
+      const db = await this.openDatabase(name);
+      return new IndexedDbStorageBackend(db);
+    } catch (e) {
+      console.warn(
+        "[webcat] Falling back to in-memory backend after IndexedDB failure",
+        e,
+      );
+      return new InMemoryStorageBackend();
+    }
   }
 
   private async openDatabase(name: string): Promise<IDBDatabase> {
@@ -61,125 +88,74 @@ export class WebcatDatabase {
     });
   }
 
-  private async settingsSet(
-    key: string,
-    value: number | string | bigint,
-  ): Promise<void> {
-    const db = await this.ensureDBOpen();
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction("settings", "readwrite");
-      const st = tx.objectStore("settings");
-      const req = st.put({ key, value });
-
-      req.onsuccess = () => resolve();
-      req.onerror = () => reject(new Error(`Failed to set ${key}`));
-    });
-  }
-
-  private async settingsGet<T>(key: string): Promise<T | null> {
-    const db = await this.ensureDBOpen();
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction("settings", "readonly");
-      const st = tx.objectStore("settings");
-      const req = st.get(key);
-
-      req.onsuccess = () => {
-        if (!req.result) return resolve(null);
-        resolve(req.result.value as T);
-      };
-
-      req.onerror = () => reject(new Error(`Failed to get ${key}`));
-    });
-  }
-
   async setLastChecked(): Promise<void> {
     const now = Date.now();
-    await this.settingsSet(KEY_LAST_CHECKED, now);
+    const backend = await this.getBackend();
+    await backend.settingsSet(KEY_LAST_CHECKED, now);
   }
 
   async getLastChecked(): Promise<number | null> {
-    return this.settingsGet<number>(KEY_LAST_CHECKED);
+    const backend = await this.getBackend();
+    return backend.settingsGet<number>(KEY_LAST_CHECKED);
   }
 
   async setLastUpdated(): Promise<void> {
     const now = Date.now();
-    await this.settingsSet(KEY_LAST_UPDATED, now);
+    const backend = await this.getBackend();
+    await backend.settingsSet(KEY_LAST_UPDATED, now);
   }
 
   async getLastUpdated(): Promise<number | null> {
-    return this.settingsGet<number>(KEY_LAST_UPDATED);
+    const backend = await this.getBackend();
+    return backend.settingsGet<number>(KEY_LAST_UPDATED);
   }
 
   async setRootHash(hash: string): Promise<void> {
-    await this.settingsSet(KEY_ROOT_HASH, hash);
+    const backend = await this.getBackend();
+    await backend.settingsSet(KEY_ROOT_HASH, hash);
   }
 
   async getRootHash(): Promise<string | null> {
-    return this.settingsGet<string>(KEY_ROOT_HASH);
+    const backend = await this.getBackend();
+    return backend.settingsGet<string>(KEY_ROOT_HASH);
   }
 
   async setLastBlockTime(seconds: bigint): Promise<void> {
-    await this.settingsSet(KEY_LAST_BLOCK_TIME, seconds);
+    const backend = await this.getBackend();
+    await backend.settingsSet(KEY_LAST_BLOCK_TIME, seconds);
   }
 
   async getLastBlockTime(): Promise<number | null> {
-    return this.settingsGet<number>(KEY_LAST_BLOCK_TIME);
+    const backend = await this.getBackend();
+    return backend.settingsGet<number>(KEY_LAST_BLOCK_TIME);
   }
 
   async setListCount(count: number): Promise<void> {
-    await this.settingsSet(KEY_LIST_COUNT, count);
+    const backend = await this.getBackend();
+    await backend.settingsSet(KEY_LIST_COUNT, count);
   }
 
   async getListCount(): Promise<number> {
-    return (await this.settingsGet<number>(KEY_LIST_COUNT)) ?? 0;
+    const backend = await this.getBackend();
+    return (await backend.settingsGet<number>(KEY_LIST_COUNT)) ?? 0;
   }
 
   async updateList(
     leaves: readonly (readonly [string, string])[],
   ): Promise<void> {
-    const db = await this.ensureDBOpen();
-    const tx = db.transaction("list", "readwrite");
-    const store = tx.objectStore("list");
+    const backend = await this.getBackend();
+    const processed = await backend.replaceList(leaves);
 
-    // 1. Remove existing entries (replace-only mode)
-    await new Promise<void>((resolve, reject) => {
-      const clearReq = store.clear();
-      clearReq.onsuccess = () => resolve();
-      clearReq.onerror = () =>
-        reject(new Error("Failed to clear old list entries"));
-    });
+    // Clear caches after list update to prevent stale data usage
+    origins.clear();
+    nonOrigins.clear();
 
-    // 2. Insert new leaves
-    const CHUNK_SIZE = 1000;
-    let processed = 0;
-
-    for (let i = 0; i < leaves.length; i += CHUNK_SIZE) {
-      const chunk = leaves.slice(i, i + CHUNK_SIZE);
-
-      for (const [reverseKey, hexHash] of chunk) {
-        const hostname = extractHostname(reverseKey);
-        const rawHash = extractRawHash(hexHash);
-
-        store.add({
-          fqdn: hostname,
-          policyhash: rawHash,
-        });
-
-        processed++;
-      }
-    }
-
-    // 3. Update stored count
-    await new Promise<void>((resolve, reject) => {
-      tx.oncomplete = () => resolve();
-      tx.onerror = () => reject(new Error("Transaction failed"));
-    });
     await this.setListCount(processed);
     console.log(`[webcat] Replaced list with ${processed} leaves`);
   }
 
   async getFQDNEnrollment(fqdn: string): Promise<Uint8Array> {
-    const db = await this.ensureDBOpen();
+    const backend = await this.getBackend();
 
     // 1. Positive-cache hit
     const originState = origins.get(fqdn);
@@ -198,21 +174,89 @@ export class WebcatDatabase {
       return new Uint8Array();
     }
 
-    // 3. IndexedDB lookup
+    // 3. Storage backend lookup
+    return backend.getEnrollmentByFqdn(fqdn);
+  }
+}
+
+class IndexedDbStorageBackend implements WebcatStorageBackend {
+  constructor(private readonly db: IDBDatabase) {}
+
+  async settingsSet(
+    key: string,
+    value: number | string | bigint,
+  ): Promise<void> {
     return new Promise((resolve, reject) => {
-      const tx = db.transaction("list", "readonly");
+      const tx = this.db.transaction("settings", "readwrite");
+      const st = tx.objectStore("settings");
+      const req = st.put({ key, value });
+
+      req.onsuccess = () => resolve();
+      req.onerror = () => reject(new Error(`Failed to set ${key}`));
+    });
+  }
+
+  async settingsGet<T>(key: string): Promise<T | null> {
+    return new Promise((resolve, reject) => {
+      const tx = this.db.transaction("settings", "readonly");
+      const st = tx.objectStore("settings");
+      const req = st.get(key);
+
+      req.onsuccess = () => {
+        if (!req.result) return resolve(null);
+        resolve(req.result.value as T);
+      };
+
+      req.onerror = () => reject(new Error(`Failed to get ${key}`));
+    });
+  }
+
+  async replaceList(
+    leaves: readonly (readonly [string, string])[],
+  ): Promise<number> {
+    const tx = this.db.transaction("list", "readwrite");
+    const store = tx.objectStore("list");
+
+    await new Promise<void>((resolve, reject) => {
+      const clearReq = store.clear();
+      clearReq.onsuccess = () => resolve();
+      clearReq.onerror = () =>
+        reject(new Error("Failed to clear old list entries"));
+    });
+
+    const CHUNK_SIZE = 1000;
+    let processed = 0;
+    for (let i = 0; i < leaves.length; i += CHUNK_SIZE) {
+      const chunk = leaves.slice(i, i + CHUNK_SIZE);
+      for (const [reverseKey, hexHash] of chunk) {
+        const hostname = extractHostname(reverseKey);
+        const rawHash = extractRawHash(hexHash);
+        store.add({ fqdn: hostname, policyhash: rawHash });
+        processed++;
+      }
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(new Error("Transaction failed"));
+    });
+
+    return processed;
+  }
+
+  async getEnrollmentByFqdn(fqdn: string): Promise<Uint8Array> {
+    return new Promise((resolve, reject) => {
+      const tx = this.db.transaction("list", "readonly");
       const store = tx.objectStore("list");
       const index = store.index("fqdnIndex");
-
       const req = index.get(fqdn);
 
       req.onsuccess = () => {
         const result = req.result;
-
         if (result && result.policyhash) {
           resolve(new Uint8Array(result.policyhash));
         } else {
-          nonOrigins.add(fqdn); // cache miss
+          nonOrigins.add(fqdn);
           resolve(new Uint8Array());
         }
       };
@@ -227,5 +271,42 @@ export class WebcatDatabase {
         reject(new Uint8Array());
       };
     });
+  }
+}
+
+class InMemoryStorageBackend implements WebcatStorageBackend {
+  private readonly settings = new Map<string, number | string | bigint>();
+  private readonly list = new Map<string, Uint8Array>();
+
+  async settingsSet(
+    key: string,
+    value: number | string | bigint,
+  ): Promise<void> {
+    this.settings.set(key, value);
+  }
+
+  async settingsGet<T>(key: string): Promise<T | null> {
+    const value = this.settings.get(key);
+    return (value as T | undefined) ?? null;
+  }
+
+  async replaceList(
+    leaves: readonly (readonly [string, string])[],
+  ): Promise<number> {
+    this.list.clear();
+    for (const [reverseKey, hexHash] of leaves) {
+      const hostname = extractHostname(reverseKey);
+      const rawHash = extractRawHash(hexHash);
+      this.list.set(hostname, new Uint8Array(rawHash));
+    }
+    return this.list.size;
+  }
+
+  async getEnrollmentByFqdn(fqdn: string): Promise<Uint8Array> {
+    const result = this.list.get(fqdn);
+    if (!result) {
+      return new Uint8Array();
+    }
+    return new Uint8Array(result);
   }
 }


### PR DESCRIPTION
This is a temporary fix for https://github.com/freedomofpress/webcat/issues/98

The WEBCAT list and update system has not an abstract storage backend. When IndexedDB is not detected, it falls back on plainn objects in memory. This is fine up until a few MBs of entries, so ok for the first few thousands. I'll leave the compatibility issue open cause there surely can be improvements.