### PR TITLE
fix (security):  hook enforcement via content script done properly

### DIFF
--- a/extension/src/webcat/genhooks.ts
+++ b/extension/src/webcat/genhooks.ts
@@ -2,18 +2,16 @@ import contentHooks from "./../../dist/hooks/content.js?raw";
 import pageHooks from "./../../dist/hooks/page.js?raw";
 import { hooksType } from "./interfaces/base";
 
-export function getHooks(type: hooksType, wasm: string[]) {
+export function getHooks(type: hooksType, wasm: string[], key: string) {
   // This just patches the script string dynamically adding per-origin WASM hashes
   if (type === hooksType.page) {
-    return pageHooks.replace(
-      '["__HASHES_PLACEHOLDER__"]',
-      JSON.stringify(wasm),
-    );
+    return pageHooks
+      .replace('["__HASHES_PLACEHOLDER__"]', JSON.stringify(wasm))
+      .replace("__KEY_PLACEHOLDER__", key);
   } else if (type === hooksType.content_script) {
-    return contentHooks.replace(
-      '["__HASHES_PLACEHOLDER__"]',
-      JSON.stringify(wasm),
-    );
+    return contentHooks
+      .replace('["__HASHES_PLACEHOLDER__"]', JSON.stringify(wasm))
+      .replace("__KEY_PLACEHOLDER__", key);
   } else {
     throw new Error(`Unknown hooks type: ${type}`);
   }

--- a/extension/src/webcat/hooks/entry-content.ts
+++ b/extension/src/webcat/hooks/entry-content.ts
@@ -1,17 +1,15 @@
-import { installHook } from "./core";
-
 console.log("[WEBCAT] Installing content script hook");
 
-(function () {
-  if (typeof window === "undefined") return;
+const pageWin = window.wrappedJSObject;
+const wasm = pageWin.WebAssembly;
 
-  if (
-    typeof window.wrappedJSObject !== "undefined" &&
-    typeof window.exportFunction === "function"
-  ) {
-    const pageWindow = window.wrappedJSObject as typeof globalThis;
-
-    const exported = window.exportFunction(installHook, pageWindow);
-    exported(pageWindow);
+function getWebAssemblyPtr(pwd: string) {
+  const key = "__KEY_PLACEHOLDER__";
+  if (pwd === key) {
+    return wasm;
   }
-})();
+}
+
+exportFunction(getWebAssemblyPtr, pageWin, { defineAs: "getWebAssemblyPtr" });
+
+delete pageWin.WebAssembly;

--- a/extension/src/webcat/hooks/entry-page.ts
+++ b/extension/src/webcat/hooks/entry-page.ts
@@ -2,4 +2,4 @@ import { installHook } from "./core";
 
 console.log("[WEBCAT] Installing page hook");
 
-installHook(globalThis);
+installHook();

--- a/extension/src/webcat/interfaces/originstate.ts
+++ b/extension/src/webcat/interfaces/originstate.ts
@@ -1,7 +1,7 @@
 import { bundle_name, bundle_prev_name } from "../../config";
 import { db } from "../../globals";
 import { canonicalize } from "../canonicalize";
-import { stringToUint8Array } from "../encoding";
+import { stringToUint8Array, Uint8ArrayToBase64Url } from "../encoding";
 import { headersListener, requestListener } from "../listeners";
 import { arraysEqual } from "../utils";
 import { SHA256 } from "../utils";
@@ -139,6 +139,7 @@ export abstract class OriginStateBase {
   public readonly valid_signers?: Set<string>;
   public readonly valid_sources?: Set<string>;
   public readonly delegation?: string;
+  public readonly hooks_key: string;
 
   // Per origin function wrappers: the extension API does not support registering
   // the same listener multiple times with different rules. We thus want a wrapper
@@ -166,6 +167,9 @@ export abstract class OriginStateBase {
     this.enrollment_hash = enrollment_hash;
     this.references = 1;
 
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    this.hooks_key = Uint8ArrayToBase64Url(bytes);
     this.onBeforeRequest = (details) => requestListener(details);
     this.onHeadersReceived = (details) => headersListener(details);
   }

--- a/extension/src/webcat/listeners.ts
+++ b/extension/src/webcat/listeners.ts
@@ -156,6 +156,7 @@ export async function headersListener(
     originStateHolder.current.manifest
   ) {
     const wasm = originStateHolder.current.manifest.wasm;
+    const hooks_key = originStateHolder.current.hooks_key;
 
     const listener = async (
       navDetails: browser.webNavigation._OnCommittedDetails,
@@ -166,7 +167,7 @@ export async function headersListener(
       browser.webNavigation.onCommitted.removeListener(listener);
 
       await browser.tabs.executeScript(details.tabId, {
-        code: getHooks(hooksType.content_script, wasm),
+        code: getHooks(hooksType.content_script, wasm, hooks_key),
         runAt: "document_start",
         frameId: details.frameId,
       });

--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -278,7 +278,11 @@ export async function validateResponseContent(
     if (details.type === "script") {
       // Inject the WASM hooks in every loaded script.
 
-      const hooks = getHooks(hooksType.page, manifest.wasm);
+      const hooks = getHooks(
+        hooksType.page,
+        manifest.wasm,
+        originStateHolder.current.hooks_key,
+      );
       filter.write(stringToUint8Array(hooks));
     }
 

--- a/extension/types/firefox.d.ts
+++ b/extension/types/firefox.d.ts
@@ -1,14 +1,14 @@
 declare global {
   interface Window {
-    wrappedJSObject?: unknown;
-
     /* eslint-disable @typescript-eslint/no-explicit-any */
-    exportFunction?<T extends (...args: any[]) => any>(
-      fn: T,
-      targetScope: object,
-      options?: unknown,
-    ): T;
+    wrappedJSObject?: any;
   }
+  /* eslint-disable @typescript-eslint/no-unsafe-function-type */
+  function exportFunction<T extends Function>(
+    func: T,
+    targetScope: object,
+    options?: { defineAs?: string },
+  ): T;
 }
 
 export {};


### PR DESCRIPTION
Turns out the previous hooking logic via the content_script injection wasn't fully working. There's the need of explicit `exportFunction` or `cloneInto` for objects to be passed between the isolated content_script world and the actual webpage. However, async functions cannot be properly cloned, as the returning Promise is a non clonable object. While for fully JS-based methods async functions [can still be passed with some workarounds](https://github.com/mdn/content/issues/15059), that doesn't seem possible when internally using native methods such as WebAssembly.InstantiateStreaming, fetch, or crypto.subtle.digest. As such, while we can override the WebAssembly page object via a content_script, we cannot properly provide an override method that works.

Thus, this PR has a slightly different approach:
 - The content_script, saves a pointer to the original WebAssembly object
 - The content_script deletes it from the page context
 - The pointer to the original WebAssembly object is gated behind a function that is password protected
 - The password is generated per origin and replaced in the script before injection
 - The page hooks check if the password protected function is available, if not it is likely being executed in a worker
 - If the function is available, recover the pointer, build the hooks, register them, and deleted the password protected functions

This seems to work security wise. However, there's one unsupported case:
 - If a page uses WebAssembly as an inline script, and doesn't load any other script beforehand, WebAssembly won't be available.

This is because the page hooks are injected via network injection in any JS file. But if no JS file is loaded before an inline script, the restoring hooks won't be available.

As expected it is a hack. Security-wise, it seems ok now but  probably not perfect

Immediate security checks that came to mind:
 - The key cannot be extracted by the page code by doing `function.toString()`. The `exportFunction` Firefox APIs exports that in a way that results as `[native code]` from the page scope.
 - The key cannot be extracted by `fetch(script.js)` because the network injection of the hooks is performed only when the file is sourced as a script
