### PR TITLE
fix: pass webcat error in url fragment

### DIFF
--- a/extension/pages/error.html
+++ b/extension/pages/error.html
@@ -3,12 +3,13 @@
   <head>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src chrome:; object-src 'none'"
+      content="default-src chrome:; object-src 'none';"
     />
     <link
       rel="stylesheet"
       href="chrome://global/skin/in-content/info-pages.css"
     />
+    <script src="error.js"></script>
     <title>Problem Loading Page</title>
   </head>
   <body>
@@ -23,7 +24,8 @@
         <p>
           If you believe this is a mistake, you may report the issue to the
           website administrator, or open an issue in the
-          <a href="https://gthub.com/freedomofpress/webcat">WEBCAT repository</a
+          <a href="https://github.com/freedomofpress/webcat"
+            >WEBCAT repository</a
           >.
         </p>
 

--- a/extension/pages/error.js
+++ b/extension/pages/error.js
@@ -1,0 +1,7 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const code = decodeURIComponent(location.hash.slice(1));
+  const el = document.getElementById("error-code");
+  if (el) {
+    el.textContent = code || "UNKNOWN";
+  }
+});

--- a/extension/src/webcat/hooks/core.ts
+++ b/extension/src/webcat/hooks/core.ts
@@ -74,7 +74,7 @@ export function wasmHook() {
 
   // Check if the WebAssembly hook has already been injected.
   if (Object.prototype.hasOwnProperty.call(wasm, "__hooked__")) {
-    console.log("WebAssembly hook already injected.");
+    console.log("[WEBCAT] WebAssembly hook already injected.");
     return;
   }
 

--- a/extension/src/webcat/ui.ts
+++ b/extension/src/webcat/ui.ts
@@ -67,40 +67,9 @@ export function setErrorIcon(tabId: number) {
 
 export async function errorpage(tabId: number, error?: WebcatError) {
   const code = error?.code ?? "WEBCAT_ERROR_UNDEFINED";
-  const errorPageUrl = browser.runtime.getURL("pages/error.html");
 
-  // Things that do not work:
-  // - Creating a blob dynamically
-  // - Rewriting the page without a redirect
+  const errorPageUrl =
+    browser.runtime.getURL("pages/error.html") + `#${encodeURIComponent(code)}`;
 
-  // Things that are nice to avoid
-  // - Query/fragment parameter passing
-  // - Messaging
-
-  // Current solution is: navigate and then inject a content script
-
-  // 1. Navigate to the error page
   await browser.tabs.update(tabId, { url: errorPageUrl });
-
-  // 2. Wait until the extension page loads
-  await new Promise<void>((resolve) => {
-    const listener = (
-      updatedTabId: number,
-      changeInfo: browser.tabs._OnUpdatedChangeInfo,
-    ) => {
-      if (updatedTabId === tabId && changeInfo.status === "complete") {
-        browser.tabs.onUpdated.removeListener(listener);
-        resolve();
-      }
-    };
-    browser.tabs.onUpdated.addListener(listener);
-  });
-
-  // 3. Dynamically inject the error code in the error page
-  browser.tabs.executeScript(tabId, {
-    code: `
-      document.getElementById("error-code").textContent = ${JSON.stringify(code)};
-    `,
-    runAt: "document_idle",
-  });
 }


### PR DESCRIPTION
Addresses https://github.com/freedomofpress/webcat/issues/118

Suboptimal cause the page will print blindly from the url fragment, but I want to avoid message passing at this stage. Script execution was imho the cleanest approach, but tbd why it doesn't work