### PR TITLE
Test in-memory cache clearing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 extension/data/
+apps/*/.well-known/webcat/

--- a/apps/testapp/webcat.config.json
+++ b/apps/testapp/webcat.config.json
@@ -1,7 +1,8 @@
 {
-    "app_name": "Webcat Demo App",
-    "app_version": "0.1",
-    "comment": "https://github.com/freedomdofpress/webcat/apps/testapp",
+    "app": "https://github.com/freedomofpress/webcat/tree/main/apps/testapp",
+    "version": "0.1",
+    "default_index": "/index.html",
+    "default_fallback": "/index.html",
     "wasm": [],
     "default_csp": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self'; frame-src 'none'; worker-src 'self';",
     "extra_csp": {}

--- a/extension/Makefile
+++ b/extension/Makefile
@@ -5,7 +5,7 @@ OUT_TEST  := $(DIST)/webcat-extension-test.zip
 INPUTS := manifest.json dist icons pages data
 FIXED_MTIME := 198001010000
 
-all: package
+all: package package-test
 
 install:
 	npm install

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,7 @@ import canonicaljson
 import hashlib
 
 from helpers import DB
+from sigsum import generate_bundle
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -28,8 +29,9 @@ def db():
     db.start()
     return db
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def root(db, request):
+    generate_bundle(request.param)
     with open(f'{request.param}/.well-known/webcat/bundle.json') as bundle:
         enrollment = json.load(bundle)["enrollment"]
         canonical_enrollment = canonicaljson.encode_canonical_json(enrollment)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,10 @@
 import os
 import pytest
+import json
+import canonicaljson
+import hashlib
+
+from helpers import DB
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -16,3 +21,18 @@ def addon_path(request):
     if not os.path.exists(abs_path):
         pytest.exit(f"Error: Addon path does not exist: {abs_path}")
     return abs_path
+
+@pytest.fixture(scope="session")
+def db():
+    db = DB()
+    db.start()
+    return db
+
+@pytest.fixture(scope="function")
+def root(db, request):
+    with open(f'{request.param}/.well-known/webcat/bundle.json') as bundle:
+        enrollment = json.load(bundle)["enrollment"]
+        canonical_enrollment = canonicaljson.encode_canonical_json(enrollment)
+        enrollment_hash = hashlib.sha256(canonical_enrollment).hexdigest()
+        db.set("127.0.0.1", enrollment_hash)
+    return request.param

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -8,6 +8,7 @@ import os
 import threading
 import http.server
 import socketserver
+from base64 import b64decode
 
 # --- Patch subprocess.Popen to discard Firefox output ---
 _original_popen = subprocess.Popen
@@ -122,6 +123,13 @@ class Browser:
 
         return value
 
+class Blob:
+    def __init__(self, data, type="text/plain", base64=False):
+        if base64:
+            self.data = b64decode(data)
+        else:
+            self.data = data
+        self.type = type
 
 class Server:
     def __init__(self, root=".", headers=None, hooks=None):
@@ -140,9 +148,16 @@ class Server:
             def do_GET(self):
                 if self.path in hooks:
                     self.send_response(200)
-                    self.send_header("Content-Type", "text/plain")
-                    self.end_headers()
-                    self.wfile.write(hooks[self.path])
+                    hook = hooks[self.path]
+                    if type(hook) is bytes:
+                        self.send_header("Content-Type", "text/plain")
+                        self.end_headers()
+                        self.wfile.write(hook)
+                    else:
+                        self.send_header("Content-Type", hook.type)
+                        self.end_headers()
+                        self.wfile.write(hook.data)
+
                 else:
                     super().do_GET()
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -38,6 +38,8 @@ class Browser:
         self.pm.create(self.profile_name)
         profile = self.pm.get_profile_by_name(self.profile_name)
         profile.set_required_configs()
+        profile.set_config("browser.shell.checkDefaultBrowser", False)
+        profile.set_config("browser.startup.couldRestoreSession.count", -1)
         logging.info(f"Profile {self.profile_name} created.")
         if headless:
             flags.append("-headless")

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -138,7 +138,6 @@ class Server:
             def do_GET(self):
                 if self.path in hooks:
                     self.send_response(200)
-                    for k, v in headers.items(): self.send_header(k, v)
                     self.send_header("Content-Type", "text/plain")
                     self.end_headers()
                     self.wfile.write(hooks[self.path])
@@ -161,3 +160,34 @@ class Server:
         self.thread.join()
 
     def url(self): return f"http://127.0.0.1:{self.port}"
+
+class DB:
+    hosts = {}
+
+    def start(db):
+        class Handler(http.server.SimpleHTTPRequestHandler):
+            def do_GET(self):
+                if self.path == "/testing-list":
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(json.dumps(db.hosts).encode())
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+
+            def log_message(self, *a): pass  # suppress logs
+
+        db.httpd = socketserver.TCPServer(("127.0.0.1", 1234), Handler, False)
+        db.httpd.allow_reuse_address = True
+        db.httpd.server_bind()
+        db.httpd.server_activate()
+        db.thread = threading.Thread(target=db.httpd.serve_forever, daemon=True)
+        db.thread.start()
+
+    def stop(db):
+        db.httpd.shutdown()
+        db.thread.join()
+
+    def set(db, host, hash):
+        db.hosts[host] = hash

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,3 @@
+canonicaljson
 geckordp
 pytest

--- a/test/sigsum.py
+++ b/test/sigsum.py
@@ -1,0 +1,47 @@
+from os import makedirs
+from os.path import abspath, join
+from tempfile import TemporaryDirectory
+from subprocess import run
+
+def generate_bundle(path):
+    path = abspath(path)
+    with TemporaryDirectory() as tmp:
+        run(["sigsum-key", "generate", "-o", "key1"], cwd=tmp, check=True)
+        hex1 = run(["sigsum-key", "to-hex", "-k", "key1.pub"], cwd=tmp, check=True, capture_output=True, text=True)
+        run(["sigsum-key", "generate", "-o", "key2"], cwd=tmp, check=True)
+        hex2 = run(["sigsum-key", "to-hex", "-k", "key2.pub"], cwd=tmp, check=True, capture_output=True, text=True)
+        with open(join(tmp, "trust_policy"), "w", encoding="utf-8") as trust_policy:
+            trust_policy.write("log 4644af2abd40f4895a003bca350f9d5912ab301a49c77f13e5b6d905c20a5fe6 https://test.sigsum.org/barreleye\n")
+            trust_policy.write("\n")
+            trust_policy.write("witness poc.sigsum.org/nisse 1c25f8a44c635457e2e391d1efbca7d4c2951a0aef06225a881e46b98962ac6c\n")
+            trust_policy.write("witness rgdd.se/poc-witness  28c92a5a3a054d317c86fc2eeb6a7ab2054d6217100d0be67ded5b74323c5806\n")
+            trust_policy.write("\n")
+            trust_policy.write("group  demo-quorum-rule any poc.sigsum.org/nisse rgdd.se/poc-witness\n")
+            trust_policy.write("quorum demo-quorum-rule\n")
+        run(["webcat", "enrollment", "create",
+             "--policy-file", "trust_policy",
+             "--threshold", "1",
+             "--max-age", "15552000",
+             "--cas-url", "https://cas.demoelement.com",
+             "--signer", hex1.stdout,
+             "--signer", hex2.stdout,
+             "--output", "enrollment.json"],
+             cwd=tmp, check=True)
+        run(["webcat", "manifest", "generate",
+             "--policy-file", "trust_policy",
+             "--config", join(path, "webcat.config.json"),
+             "--directory", path,
+             "--output", "manifest_unsigned.json"],
+            cwd=tmp, check=True)
+        run(["webcat", "manifest", "sign",
+             "--policy-file", "trust_policy",
+             "-i", "manifest_unsigned.json",
+             "-k", "key1",
+             "-o", "manifest.json"],
+            cwd=tmp, check=True)
+        makedirs(join(path, ".well-known/webcat"), exist_ok=True)
+        run(["webcat", "bundle", "create",
+             "--enrollment", "enrollment.json",
+             "--manifest", "manifest.json",
+             "--output", join(path, ".well-known/webcat/bundle.json")],
+            cwd=tmp, check=True)

--- a/test/tests.py
+++ b/test/tests.py
@@ -2,7 +2,6 @@ import pytest
 from time import sleep
 from helpers import Browser, Server
 import logging
-import pytest
 
 logging.getLogger("geckordp").setLevel(logging.CRITICAL)
 logging.getLogger("psutil").setLevel(logging.CRITICAL)
@@ -31,128 +30,57 @@ def teardown_browser_and_server(srv, browser):
     browser.destroy()
 
 
-@pytest.mark.parametrize("headers, hooks, expected", [
+@pytest.mark.parametrize("root, headers, hooks, expected", [
     # Basic correct execution
-    ({
-        "x-sigstore-signers": '[{"identity": "giulio@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "cory@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "github@lsd.cat", "issuer": "https://github.com/login/oauth"}]',
-        "x-sigstore-threshold": "2",
+    ("cases/testapp", {
         "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
                                    "style-src 'self'; frame-src 'none'; worker-src 'self';"
     }, {}, "Hello!"),
 
-    # Full stripping
-    ({
-        "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
-                                   "style-src 'self'; frame-src 'none'; worker-src 'self';"
-    }, {}, "Something went wrong. The request was blocked."),
-
-    # Wrong threshold
-    ({
-        "x-sigstore-signers": '[{"identity": "giulio@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "cory@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "github@lsd.cat", "issuer": "https://github.com/login/oauth"}]',
-        "x-sigstore-threshold": "1",
-        "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
-                                   "style-src 'self'; frame-src 'none'; worker-src 'self';"
-    }, {}, "Something went wrong. The request was blocked."),
-
-    # Wrong signers
-    ({
-        "x-sigstore-signers": '[{"identity": "giulio@test.com", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "cory@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "github@lsd.cat", "issuer": "https://github.com/login/oauth"}]',
-        "x-sigstore-threshold": "2",
-        "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
-                                   "style-src 'self'; frame-src 'none'; worker-src 'self';"
-    }, {}, "Something went wrong. The request was blocked."),
-
     # Wrong CSP
-    ({
-        "x-sigstore-signers": '[{"identity": "giulio@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "cory@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "github@lsd.cat", "issuer": "https://github.com/login/oauth"}]',
-        "x-sigstore-threshold": "2",
+    ("cases/testapp", {
         "content-security-policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
                                    "style-src 'self'; frame-src 'none'; worker-src 'self';"
-    }, {}, "Something went wrong. The request was blocked."),
-
-    # Missing threshold
-    ({
-        "x-sigstore-signers": '[{"identity": "giulio@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "cory@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "github@lsd.cat", "issuer": "https://github.com/login/oauth"}]',
-        "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
-                                   "style-src 'self'; frame-src 'none'; worker-src 'self';"
-    }, {}, "Something went wrong. The request was blocked."),
-
-    # Missing signers
-    ({
-        "x-sigstore-threshold": "2",
-        "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
-                                   "style-src 'self'; frame-src 'none'; worker-src 'self';"
-    }, {"/hello": b"Hi from test!"}, "Something went wrong. The request was blocked."),
+    }, {}, "ERR_WEBCAT_CSP_MISMATCH"),
 
     # Missing CSP
-    ({
-        "x-sigstore-signers": '[{"identity": "giulio@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "cory@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "github@lsd.cat", "issuer": "https://github.com/login/oauth"}]',
-        "x-sigstore-threshold": "2"
+    ("cases/testapp", {
         # No CSP header
-    }, {}, "Something went wrong. The request was blocked."),
+    }, {}, "ERR_WEBCAT_HEADERS_MISSING_CRITICAL"),
 
     # Hook / with static content
-    ({
-        "x-sigstore-signers": '[{"identity": "giulio@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "cory@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "github@lsd.cat", "issuer": "https://github.com/login/oauth"}]',
-        "x-sigstore-threshold": "2",
+    ("cases/testapp", {
         "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
                                    "style-src 'self'; frame-src 'none'; worker-src 'self';"
-    }, {"/": b"<html><body>replaced index</body></html>"}, "Something went wrong. The request was blocked."),
-    # Hook /webcat.json
-    ({
-        "x-sigstore-signers": '[{"identity": "giulio@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "cory@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "github@lsd.cat", "issuer": "https://github.com/login/oauth"}]',
-        "x-sigstore-threshold": "2",
+    }, {"/": b"<html><body>replaced index</body></html>"}, "ERR_WEBCAT_FILE_MISMATCH"),
+    # Hook /.well-known/webcat/bundle.json
+    ("cases/testapp", {
         "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
                                    "style-src 'self'; frame-src 'none'; worker-src 'self';"
-    }, {"/webcat.json": b'{"a":"b"}'}, "Something went wrong. The request was blocked."),
+    }, {"/.well-known/webcat/bundle.json": b'{"a":"b"}'}, "ERR_WEBCAT_BUNDLE_MISSING_ENROLLMENT"),
     # Hook /js/alert.js
-    ({
-        "x-sigstore-signers": '[{"identity": "giulio@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "cory@freedom.press", "issuer": "https://accounts.google.com"}, '
-                              '{"identity": "github@lsd.cat", "issuer": "https://github.com/login/oauth"}]',
-        "x-sigstore-threshold": "2",
+    ("cases/testapp", {
         "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
                                    "style-src 'self'; frame-src 'none'; worker-src 'self';"
-    }, {"/js/alert.js": b"alert('hacked');"}, "Something went wrong. The request was blocked."),
+    }, {"/js/alert.js": b"alert('hacked');"}, "ERR_WEBCAT_FILE_MISMATCH"),
 
 ], ids=[
     "basic_test",
-    "stripping_test",
-    "wrong_threshold_test",
-    "wrong_signers_test",
     "wrong_csp_test",
-    "missing_threshold_test",
-    "missing_signers_test",
     "missing_csp_test",
     "corrupted_index_test",
     "corrupted_manifest_test",
     "corrupted_js_test"
-])
-def test_webcat(headers, hooks, expected, addon_path):
+], indirect=["root"])
+def test_webcat(root, headers, hooks, expected, addon_path):  
     srv, browser = setup_browser_and_server(
-        root="cases/testapp",
+        root=root,
         headers=headers,
         hooks=hooks,
         extension_path=addon_path
     )
     try:
         res = browser.execute("document.body.innerText")
-        assert res == expected
+        assert expected in res
     finally:
         teardown_browser_and_server(srv, browser)

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,6 +1,6 @@
 import pytest
 from time import sleep
-from helpers import Browser, Server
+from helpers import Browser, Server, Blob
 import logging
 
 logging.getLogger("geckordp").setLevel(logging.CRITICAL)
@@ -24,11 +24,9 @@ def setup_browser_and_server(root, headers=None, hooks=None, extension_path=None
     sleep(2)
     return srv, browser
 
-
 def teardown_browser_and_server(srv, browser):
     srv.stop()
     browser.destroy()
-
 
 @pytest.mark.parametrize("root, headers, hooks, expected", [
     # Basic correct execution
@@ -72,7 +70,7 @@ def teardown_browser_and_server(srv, browser):
     "corrupted_manifest_test",
     "corrupted_js_test"
 ], indirect=["root"])
-def test_webcat(root, headers, hooks, expected, addon_path):  
+def test_webcat(root, headers, hooks, expected, addon_path):
     srv, browser = setup_browser_and_server(
         root=root,
         headers=headers,
@@ -82,5 +80,39 @@ def test_webcat(root, headers, hooks, expected, addon_path):
     try:
         res = browser.execute("document.body.innerText")
         assert expected in res
+    finally:
+        teardown_browser_and_server(srv, browser)
+
+@pytest.mark.parametrize("root", [("cases/testapp")], indirect=["root"])
+def test_in_memory_cache(root, addon_path):
+    srv, browser = setup_browser_and_server(
+        root=root,
+        headers={
+            "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
+                                       "style-src 'self'; frame-src 'none'; worker-src 'self';",
+            "cache-control": "max-age=180"
+        },
+        hooks={"/console_log.png": Blob(
+            "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAABGdBTUEAALGPC/xhBQAAACBjSFJN"
+            "AAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAAAHdElN"
+            "RQfoChYSHzod9YOfAAABNUlEQVQoz1XRv0ubARDG8c+bvMFW/BFfaAMupZWKgoPULQWXgg3orFBE"
+            "cHNQ3Do46aJQFP8EB8Glg7qIOrjYuSKpguDiKNomaaEIaXw7vPZNfW457r4cd/dkNRXoUJBHXdws"
+            "JsroM6Lgj0DoxqEz900gZ8KgfV8FfntiSEnZljpZMO6lNeeKlpwYVbfhvW7lZHyfT7rwzpVb0/bM"
+            "I7KmPwHmlPDaqVjDN5tGQMk8tFlWwLr4IWqOvcVzKzoy8gIVL4yl5+7asSBS1ZDPCNBiRk8KjJpT"
+            "MuVeIAjVMGM2/QiRCHfahaqhn35Y1Oqxjm1741oNel2kC8YavvjolU6rBv7xH1RS4LNnaLdgqjkw"
+            "a9KlWOy7ojbDVkzKJS2IlR24FqsIFUV2HWn872aSP5WXU/UrcRL+AtouWZWI+tGIAAAAJXRFWHRk"
+            "YXRlOmNyZWF0ZQAyMDI0LTEwLTIyVDE4OjIxOjM3KzAwOjAwXUyimQAAACV0RVh0ZGF0ZTptb2Rp"
+            "ZnkAMjAyNC0xMC0yMlQxNDo1Mzo0MyswMDowMGXvS2oAAAAASUVORK5CYII=",
+            type="image/png", base64=True)}
+    )
+    browser.navigate(f'{srv.url()}/console_log.png')
+    sleep(2)
+    browser.install_extension(addon_path)
+    sleep(7)
+    browser.navigate(f'{srv.url()}/console_log.png')
+    sleep(2)
+    try:
+        res = browser.execute("document.body.innerText")
+        assert "ERR_WEBCAT_FILE_MISMATCH" in res
     finally:
         teardown_browser_and_server(srv, browser)


### PR DESCRIPTION
This PR makes a minor addition to the integration test setup, allowing hooked server paths to specify a content-type via a new `Blob` class. This is needed to serve images from hooked paths.

The test in this PR fails before #138. The branch is based off of #141.