### PR TITLE
Fix linting in CI

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm ci
 
       - name: Run Linter
-        run: npm run lint
+        run: npm run lint:check
 
   test:
     name: Tests

--- a/extension/Readme.md
+++ b/extension/Readme.md
@@ -32,9 +32,13 @@ npm run test:playwright
 
 ### Linting
 
-The project currently use [eslint](eslint.config.mjs) for linting and prettifier for sorting imports and style consistency. Both are run together with:
+The project uses [eslint](eslint.config.mjs) for linting and [prettier](https://prettier.io/) for sorting imports and style consistency. Both are run together with:
 
 `npm run lint`
+
+To check for issues without auto-fixing (this is what CI runs):
+
+`npm run lint:check`
 
 ### Decision tree
 

--- a/extension/eslint.config.mjs
+++ b/extension/eslint.config.mjs
@@ -3,6 +3,10 @@ import globals from "globals";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 
 export default [
+  {
+    ignores: ["dist/**"],
+  },
+
   ...tseslint.configs.recommended,
 
   {

--- a/extension/package.json
+++ b/extension/package.json
@@ -11,7 +11,8 @@
     "coverage": "npm run build:hooks && vitest --coverage",
     "test:playwright": "vitest --config vite.config.playwright.ts",
     "test:default": "vitest --config vite.config.ts",
-    "lint": "npx eslint . --fix && npx prettier --write ."
+    "lint": "npx eslint . --fix && npx prettier --write .",
+    "lint:check": "npx eslint . && npx prettier --check ."
   },
   "author": "Giulio B",
   "license": "MIT",

--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -263,7 +263,11 @@ export async function validateResponseContent(
     if (!manifest_hash) {
       deny(filter);
       filter.close();
-      errorpage(details.tabId, fqdn, new WebcatError(WebcatErrorCode.File.MISSING));
+      errorpage(
+        details.tabId,
+        fqdn,
+        new WebcatError(WebcatErrorCode.File.MISSING),
+      );
     }
 
     const content_hash = await SHA256(blob);
@@ -278,7 +282,8 @@ export async function validateResponseContent(
       deny(filter);
       filter.close();
       errorpage(
-        details.tabId, fqdn,
+        details.tabId,
+        fqdn,
         new WebcatError(WebcatErrorCode.File.MISMATCH, [
           String(manifest_hash),
           String(Uint8ArrayToBase64Url(new Uint8Array(content_hash))),

--- a/extension/src/webcat/ui.ts
+++ b/extension/src/webcat/ui.ts
@@ -65,7 +65,11 @@ export function setErrorIcon(tabId: number) {
   });
 }
 
-export async function errorpage(tabId: number, fqdn: string, error?: WebcatError) {
+export async function errorpage(
+  tabId: number,
+  fqdn: string,
+  error?: WebcatError,
+) {
   const code = error?.code ?? "WEBCAT_ERROR_UNDEFINED";
 
   const errorPageUrl =
@@ -74,6 +78,6 @@ export async function errorpage(tabId: number, fqdn: string, error?: WebcatError
   await browser.tabs.update(tabId, { url: errorPageUrl });
 
   // See https://github.com/freedomofpress/webcat/issues/137
-  await browser.browsingData.remove( { hostnames: [fqdn] }, { cache: true });
+  await browser.browsingData.remove({ hostnames: [fqdn] }, { cache: true });
   await browser.webRequest.handlerBehaviorChanged();
 }


### PR DESCRIPTION
There was linting in the `pr-checks` CI workflow, but it did not throw on error. Linting was also not documented.

This PR changes add a `lint:check` that should exit on error rather than fixing and updates the workflow accordingly. Adds also basic information about linting in the Readme and applies the linting to non-compliant files.