### PR TITLE
Set up integration tests with Tor Browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 extension/data/
 apps/*/.well-known/webcat/
+__pycache__

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,6 +3,13 @@ PYTHON=$(VENV)/bin/python
 PIP=$(VENV)/bin/pip
 PYTEST=$(VENV)/bin/pytest
 
+TESTARGS ?= --addon ../dist/webcat-extension-test.zip
+BENCHARGS ?= --iterations 5
+
+ifdef HEADLESS
+	TESTARGS += --headless
+endif
+
 .PHONY: all venv install test clean
 
 all: test
@@ -15,10 +22,10 @@ install: venv
 	$(PIP) install -r requirements.txt
 
 test: install
-	$(PYTEST) -v tests.py --addon ../dist/webcat-extension-test.zip
+	$(PYTEST) -v tests.py $(TESTARGS)
 
 benchmark: install
-	$(PYTHON) benchmarks.py --addon ../dist/webcat-extension-test.zip --iterations 5
+	$(PYTHON) benchmarks.py $(TESTARGS) $(BENCHARGS)
 
 clean:
 	rm -rf $(VENV) __pycache__ .pytest_cache

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,55 @@
+# webcat integration tests
+
+## Prerequisites
+
+- Python 3
+- Firefox
+- Tor Browser (optional, for Tor tests)
+
+### Linux
+
+Install Firefox via your package manager. For Tor Browser, ensure `start-tor-browser` is in your `$PATH`.
+
+### macOS
+
+Install Firefox normally. For Tor Browser, install it to `/Applications/Tor Browser.app`.
+
+## Running tests
+
+```bash
+make test
+```
+
+### Headless mode
+
+Run without a visible browser window:
+
+```bash
+HEADLESS=1 make test
+```
+
+### Running only Firefox or Tor tests
+
+Tests are parametrized across `firefox` and `tor` browsers. Use `-k` to filter:
+
+```bash
+# Firefox only
+cd test && .venv/bin/pytest -v tests.py --addon ../dist/webcat-extension-test.zip -k firefox
+
+# Tor only
+cd test && .venv/bin/pytest -v tests.py --addon ../dist/webcat-extension-test.zip -k tor
+```
+
+### Running a specific test
+
+```bash
+cd test && .venv/bin/pytest -v tests.py --addon ../dist/webcat-extension-test.zip -k "test_webcat and firefox"
+```
+
+### Extra pytest arguments
+
+Pass additional arguments via `TESTARGS`:
+
+```bash
+make test TESTARGS="--addon ../dist/webcat-extension-test.zip -k firefox --headless"
+```

--- a/test/benchmarks.py
+++ b/test/benchmarks.py
@@ -72,7 +72,8 @@ class PerformanceTester:
         url = f"http://{self.host}:{srv.port}/"
 
         def setup_browser():
-            browser = Browser(self.headless)
+            browser = Browser()
+            browser.start(self.headless)
             if self.addon_path:
                 try:
                     browser.install_extension(self.addon_path)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,13 +4,17 @@ import json
 import canonicaljson
 import hashlib
 
-from helpers import DB
+from helpers import Browser, DB, Server, TorBrowser
 from sigsum import generate_bundle
 
 def pytest_addoption(parser):
     parser.addoption(
         "--addon", action="store", default=None,
         help="Path to the webcat test addon zip file"
+    )
+    parser.addoption(
+        "--headless", action="store_true",
+        help="Run the browser in headless mode"
     )
 
 @pytest.fixture(scope="session")
@@ -38,3 +42,26 @@ def root(db, request):
         enrollment_hash = hashlib.sha256(canonical_enrollment).hexdigest()
         db.set("127.0.0.1", enrollment_hash)
     return request.param
+
+@pytest.fixture(scope="function")
+def server(root, headers, hooks):
+    s = Server(
+        root=root,
+        headers=headers or {},
+        hooks=hooks or {}
+    )
+    s.start()
+    yield s
+    s.stop()
+
+@pytest.fixture(scope="function")
+def browser(request):
+    if request.param == "firefox":
+        b = Browser()
+    elif request.param == "tor":
+        b = TorBrowser(allowed_addons=["webcat@freedom.press"])
+    else:
+        raise RuntimeError(f'unrecognized brwser \'{request.param}\'')
+    b.start(request.config.getoption("--headless"))
+    yield b
+    b.destroy()

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -70,7 +70,7 @@ class Browser:
             pass
         try:
             self.pm.remove(self.profile_name)
-            logging.info("Profile {self.profile_name} removed.")
+            logging.info(f"Profile {self.profile_name} removed.")
         except:
             pass
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -9,6 +9,7 @@ import threading
 import http.server
 import socketserver
 from base64 import b64decode
+from pathlib import Path
 
 # --- Patch subprocess.Popen to discard Firefox output ---
 _original_popen = subprocess.Popen
@@ -31,32 +32,39 @@ from geckordp.profile import ProfileManager
 from geckordp.rdp_client import RDPClient
 
 class Browser:
-    def __init__(self, headless=False, start="about:blank", flags=[], port=6000):
-        self.port = port
+    def __init__(self, override_firefox_path="", override_profiles_path="", additional_configs={}):
         self.host = "127.0.0.1"
         self.profile_name = f"geckordp-{uuid.uuid4()}"
-        self.pm = ProfileManager()
+        self.override_firefox_path = override_firefox_path
+        self.pm = ProfileManager(override_firefox_path, override_profiles_path)
         self.pm.create(self.profile_name)
         profile = self.pm.get_profile_by_name(self.profile_name)
+        self.profile_path = profile.path
         profile.set_required_configs()
         profile.set_config("browser.shell.checkDefaultBrowser", False)
         profile.set_config("browser.startup.couldRestoreSession.count", -1)
+        for key, value in additional_configs.items():
+            profile.set_config(key, value)
         logging.info(f"Profile {self.profile_name} created.")
+        subprocess.Popen(["pkill", "-f", f'\\-P {self.profile_name}']) # TBB hack
+
+    def start(self, headless=False, start="about:blank", flags=[], port=6000):
+        self.port = port
         if headless:
             flags.append("-headless")
-        Firefox.start(start, self.port, self.profile_name, flags)
+        Firefox.start(start, self.port, self.profile_name, flags, self.override_firefox_path, False)
         logging.info("Firefox started.")
         self.client = RDPClient()
         self.client.connect(self.host, self.port)
         logging.info("RDP connection established.")
         self.root = RootActor(self.client)
-
     
     def destroy(self):
         self.client.disconnect()
         logging.info("RDP disconnected.")
         try:
             _kill_instances()
+            subprocess.Popen(["pkill", "-f", f'\\-p {self.profile_name}']) # TBB hack
             logging.info("Firefox process killed.")
         except:
             pass
@@ -122,6 +130,37 @@ class Browser:
             value = result_field
 
         return value
+    
+class TorBrowser(Browser):
+    @staticmethod
+    def get_binary_path():
+        try:
+            return Path(subprocess.check_output(["which", "start-tor-browser"]).decode().strip())
+        except subprocess.CalledProcessError:
+            raise RuntimeError("'start-tor-browser' not found in $PATH")
+    
+    @staticmethod
+    def get_profiles_path():
+        return Path(os.path.dirname(TorBrowser.get_binary_path())).joinpath("TorBrowser/Data/Browser/")
+
+    def __init__(self, override_tbb_path="", override_profiles_path="", additional_configs={}, allowed_addons=[]):
+        if override_tbb_path == "":
+            override_tbb_path = TorBrowser.get_binary_path()
+        if override_profiles_path == "":
+            override_profiles_path = TorBrowser.get_profiles_path()
+        additional_configs["network.proxy.allow_hijacking_localhost"] = False
+        super().__init__(override_tbb_path, override_profiles_path, additional_configs)
+        if len(allowed_addons) > 0:
+            with open(self.profile_path.joinpath("extension-preferences.json"), "r") as file:
+                prefs = json.load(file)
+            for addon in allowed_addons:
+                prefs[addon] = {
+                    "permissions": ["internal:privateBrowsingAllowed"],
+                    "origins": [],
+                    "data_collection": []
+                }
+            with open(self.profile_path.joinpath("extension-preferences.json"), "w") as file:
+                json.dump(prefs, file)
 
 class Blob:
     def __init__(self, data, type="text/plain", base64=False):

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -5,6 +5,7 @@ import queue
 import logging
 import subprocess
 import os
+import sys
 import threading
 import http.server
 import socketserver
@@ -134,13 +135,20 @@ class Browser:
 class TorBrowser(Browser):
     @staticmethod
     def get_binary_path():
+        if sys.platform == "darwin":
+            path = Path("/Applications/Tor Browser.app/Contents/MacOS/firefox")
+            if path.exists():
+                return path
+            raise RuntimeError("Tor Browser.app not found in /Applications")
         try:
             return Path(subprocess.check_output(["which", "start-tor-browser"]).decode().strip())
         except subprocess.CalledProcessError:
             raise RuntimeError("'start-tor-browser' not found in $PATH")
-    
+
     @staticmethod
     def get_profiles_path():
+        if sys.platform == "darwin":
+            return Path.home() / "Library" / "Application Support" / "TorBrowser-Data" / "Browser"
         return Path(os.path.dirname(TorBrowser.get_binary_path())).joinpath("TorBrowser/Data/Browser/")
 
     def __init__(self, override_tbb_path="", override_profiles_path="", additional_configs={}, allowed_addons=[]):

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,6 +1,6 @@
 import pytest
 from time import sleep
-from helpers import Browser, Server, Blob
+from helpers import TorBrowser, Server, Blob
 import logging
 
 logging.getLogger("geckordp").setLevel(logging.CRITICAL)
@@ -13,7 +13,8 @@ def setup_browser_and_server(root, headers=None, hooks=None, extension_path=None
         headers=headers or {},
         hooks=hooks or {}
     )
-    browser = Browser(headless=headless)
+    browser = TorBrowser(allowed_addons=["webcat@freedom.press"])
+    browser.start(headless)
     if extension_path:
         browser.install_extension(extension_path)
         sleep(7)

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,34 +1,26 @@
 import pytest
 from time import sleep
-from helpers import TorBrowser, Server, Blob
+from helpers import Browser, Server, Blob
 import logging
 
 logging.getLogger("geckordp").setLevel(logging.CRITICAL)
 logging.getLogger("psutil").setLevel(logging.CRITICAL)
 logging.getLogger().setLevel(logging.WARNING)
 
-def setup_browser_and_server(root, headers=None, hooks=None, extension_path=None, headless=False):
-    srv = Server(
-        root=root,
-        headers=headers or {},
-        hooks=hooks or {}
-    )
-    browser = TorBrowser(allowed_addons=["webcat@freedom.press"])
-    browser.start(headless)
-    if extension_path:
-        browser.install_extension(extension_path)
-        sleep(7)
+WEBCAT_ICON = Blob(
+    "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAABGdBTUEAALGPC/xhBQAAACBjSFJN"
+    "AAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAAAHdElN"
+    "RQfoChYSHzod9YOfAAABNUlEQVQoz1XRv0ubARDG8c+bvMFW/BFfaAMupZWKgoPULQWXgg3orFBE"
+    "cHNQ3Do46aJQFP8EB8Glg7qIOrjYuSKpguDiKNomaaEIaXw7vPZNfW457r4cd/dkNRXoUJBHXdws"
+    "JsroM6Lgj0DoxqEz900gZ8KgfV8FfntiSEnZljpZMO6lNeeKlpwYVbfhvW7lZHyfT7rwzpVb0/bM"
+    "I7KmPwHmlPDaqVjDN5tGQMk8tFlWwLr4IWqOvcVzKzoy8gIVL4yl5+7asSBS1ZDPCNBiRk8KjJpT"
+    "MuVeIAjVMGM2/QiRCHfahaqhn35Y1Oqxjm1741oNel2kC8YavvjolU6rBv7xH1RS4LNnaLdgqjkw"
+    "a9KlWOy7ojbDVkzKJS2IlR24FqsIFUV2HWn872aSP5WXU/UrcRL+AtouWZWI+tGIAAAAJXRFWHRk"
+    "YXRlOmNyZWF0ZQAyMDI0LTEwLTIyVDE4OjIxOjM3KzAwOjAwXUyimQAAACV0RVh0ZGF0ZTptb2Rp"
+    "ZnkAMjAyNC0xMC0yMlQxNDo1Mzo0MyswMDowMGXvS2oAAAAASUVORK5CYII=",
+    type="image/png", base64=True)
 
-    srv.start()
-    sleep(1)
-    browser.navigate(srv.url())
-    sleep(2)
-    return srv, browser
-
-def teardown_browser_and_server(srv, browser):
-    srv.stop()
-    browser.destroy()
-
+@pytest.mark.parametrize("browser", ["firefox", "tor"], indirect=True)
 @pytest.mark.parametrize("root, headers, hooks, expected", [
     # Basic correct execution
     ("cases/testapp", {
@@ -71,49 +63,28 @@ def teardown_browser_and_server(srv, browser):
     "corrupted_manifest_test",
     "corrupted_js_test"
 ], indirect=["root"])
-def test_webcat(root, headers, hooks, expected, addon_path):
-    srv, browser = setup_browser_and_server(
-        root=root,
-        headers=headers,
-        hooks=hooks,
-        extension_path=addon_path
-    )
-    try:
-        res = browser.execute("document.body.innerText")
-        assert expected in res
-    finally:
-        teardown_browser_and_server(srv, browser)
+def test_webcat(browser, server, expected, addon_path):
+    browser.install_extension(addon_path)
+    sleep(7)
+    browser.navigate(server.url())
+    sleep(2)
+    res = browser.execute("document.body.innerText")
+    assert expected in res
 
-@pytest.mark.parametrize("root", [("cases/testapp")], indirect=["root"])
-def test_in_memory_cache(root, addon_path):
-    srv, browser = setup_browser_and_server(
-        root=root,
-        headers={
-            "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
-                                       "style-src 'self'; frame-src 'none'; worker-src 'self';",
-            "cache-control": "max-age=180"
-        },
-        hooks={"/console_log.png": Blob(
-            "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAABGdBTUEAALGPC/xhBQAAACBjSFJN"
-            "AAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAAAHdElN"
-            "RQfoChYSHzod9YOfAAABNUlEQVQoz1XRv0ubARDG8c+bvMFW/BFfaAMupZWKgoPULQWXgg3orFBE"
-            "cHNQ3Do46aJQFP8EB8Glg7qIOrjYuSKpguDiKNomaaEIaXw7vPZNfW457r4cd/dkNRXoUJBHXdws"
-            "JsroM6Lgj0DoxqEz900gZ8KgfV8FfntiSEnZljpZMO6lNeeKlpwYVbfhvW7lZHyfT7rwzpVb0/bM"
-            "I7KmPwHmlPDaqVjDN5tGQMk8tFlWwLr4IWqOvcVzKzoy8gIVL4yl5+7asSBS1ZDPCNBiRk8KjJpT"
-            "MuVeIAjVMGM2/QiRCHfahaqhn35Y1Oqxjm1741oNel2kC8YavvjolU6rBv7xH1RS4LNnaLdgqjkw"
-            "a9KlWOy7ojbDVkzKJS2IlR24FqsIFUV2HWn872aSP5WXU/UrcRL+AtouWZWI+tGIAAAAJXRFWHRk"
-            "YXRlOmNyZWF0ZQAyMDI0LTEwLTIyVDE4OjIxOjM3KzAwOjAwXUyimQAAACV0RVh0ZGF0ZTptb2Rp"
-            "ZnkAMjAyNC0xMC0yMlQxNDo1Mzo0MyswMDowMGXvS2oAAAAASUVORK5CYII=",
-            type="image/png", base64=True)}
-    )
-    browser.navigate(f'{srv.url()}/console_log.png')
+@pytest.mark.parametrize("browser", ["firefox", "tor"], indirect=True)
+@pytest.mark.parametrize("root, headers, hooks, expected", [
+    ("cases/testapp", {
+        "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
+                                   "style-src 'self'; frame-src 'none'; worker-src 'self';",
+        "cache-control": "max-age=180"
+    }, {"/console_log.png": WEBCAT_ICON}, "ERR_WEBCAT_FILE_MISMATCH"),
+], indirect=["root"])
+def test_in_memory_cache(browser, server, expected, addon_path):
+    browser.navigate(f'{server.url()}/console_log.png')
     sleep(2)
     browser.install_extension(addon_path)
     sleep(7)
-    browser.navigate(f'{srv.url()}/console_log.png')
+    browser.navigate(f'{server.url()}/console_log.png')
     sleep(2)
-    try:
-        res = browser.execute("document.body.innerText")
-        assert "ERR_WEBCAT_FILE_MISMATCH" in res
-    finally:
-        teardown_browser_and_server(srv, browser)
+    res = browser.execute("document.body.innerText")
+    assert expected in res


### PR DESCRIPTION
This PR hooks up Tor browser to the integration tests, in addition to Firefox. All existing integration tests pass on Tor Browser with no issues.

Getting Tor Browser to work with geckordp and the local test server required a couple of dirty hacks:

1. Because `start-tor-browser` is a shell script that launches another `firefox` shell script that finally executes the `firefox.real` binary, geckordp is not able to kill it properly when it needs to. This PR kills stray browser instances using `pkill -f`, using the profile name to identify what to kill.
2. As there is no standard installation location for Tor Browser, the tests assume the `start-tor-browser` shell script is in `$PATH` and fail with a `RuntimeError` if that's not the case.
3. The WEBCAT extension needs to be given permission to run in private browsing mode. That's done by editing the `extension-preferences.json` file in the browser profile.
4. Localhost can't be accessed through the Tor proxy, so the proxy is reconfigured not to hijack localhost.

This PR also cleans up the `tests.py` file, moving server and browser setup and teardown into fixtures. Headless mode is exposed through a new pytest option as well as a variable in the Makefile: integration tests can now be run in headless mode via `make test HEADLESS=1`.