### PR TITLE
fix: cleanup code and do update check time-relative

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -16,6 +16,7 @@
   },
   "incognito": "spanning",
   "permissions": [
+    "alarms",
     "browsingData",
     "webNavigation",
     "webRequest",

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -9,18 +9,33 @@ import {
 } from "./webcat/listeners";
 import { FRAME_TYPES } from "./webcat/resources";
 import { setErrorIcon } from "./webcat/ui";
-import { update } from "./webcat/update";
-import { initializeScheduledUpdates } from "./webcat/update";
+import {
+  handleUpdateAlarm,
+  initializeScheduledUpdates,
+  update,
+} from "./webcat/update";
 
 console.log("[webcat] Starting up background");
 
-setTimeout(async () => {
-  console.log("[webcat] Importing bundled list");
-  await update(db, endpoint, true);
+// Import bundled list and initialize scheduled updates
+(async () => {
+  try {
+    console.log("[webcat] Importing bundled list");
+    await update(db, endpoint, true);
+  } catch (error) {
+    console.error("[webcat] Bundled list import failed:", error);
+  }
 
   console.log("[webcat] Attempting network update");
   await initializeScheduledUpdates(db, endpoint);
-}, 0);
+})();
+
+// Listen for the update alarm
+browser.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === "webcat-scheduled-update") {
+    handleUpdateAlarm(db, endpoint);
+  }
+});
 
 // Let's count references to origin in case we ever need pruning policies
 browser.tabs.onRemoved.addListener(tabCloseListener);

--- a/extension/src/config.ts
+++ b/extension/src/config.ts
@@ -7,3 +7,8 @@ export const lru_cache_size = 32;
 // Items here are just the size in bytes for a domain
 export const lru_set_size = 8192;
 export const endpoint = "https://webcat.freedom.press/";
+// During alpha, update every hour. Wall-clock based so that sleep/suspend
+// doesn't silently postpone updates.
+export const UPDATE_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+export const CHECK_INTERVAL_MS = 5 * 60 * 1000; // poll every 5 minutes
+export const FETCH_TIMEOUT_MS = 3000; // 3 second timeout for fetches

--- a/extension/src/webcat/update.ts
+++ b/extension/src/webcat/update.ts
@@ -41,80 +41,41 @@ async function fetchWithTimeout(
   }
 }
 
-// Check if we should do scheduled daily update
-function shouldDoScheduledUpdate(lastUpdated: number | null): boolean {
-  const now = Date.now();
-  const nowUTC = new Date(now);
+// During alpha, update every hour. Wall-clock based so that sleep/suspend
+// doesn't silently postpone updates.
+export const UPDATE_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+export const CHECK_INTERVAL_MS = 5 * 60 * 1000; // poll every 5 minutes
 
-  // Calculate today's scheduled update time (01:10 UTC)
-  const todayScheduled = new Date(
-    Date.UTC(
-      nowUTC.getUTCFullYear(),
-      nowUTC.getUTCMonth(),
-      nowUTC.getUTCDate(),
-      1, // hour
-      10, // minute
-      0, // second
-      0, // millisecond
-    ),
-  ).getTime();
-
-  // If we haven't passed today's scheduled time yet, check yesterday's
-  const scheduledTime =
-    now >= todayScheduled
-      ? todayScheduled
-      : todayScheduled - 24 * 60 * 60 * 1000;
-
-  // Update if we've never updated, or if last update was before the most recent scheduled time
-  return lastUpdated === null || lastUpdated < scheduledTime;
+// Check if we should do an update at startup (overdue check)
+export function shouldDoScheduledUpdate(lastUpdated: number | null): boolean {
+  return lastUpdated === null || Date.now() - lastUpdated >= UPDATE_INTERVAL_MS;
 }
 
-// Schedule the next daily update check
+// Start the wall-clock polling loop for scheduled updates.
 function scheduleNextUpdate(db: WebcatDatabase, endpoint: string): void {
   if (scheduledUpdateTimer !== null) {
     clearTimeout(scheduledUpdateTimer);
   }
 
-  /*const now = Date.now();
-  const nowUTC = new Date(now);
-
-  // Calculate next scheduled update time (01:10 UTC)
-  let nextScheduled = new Date(
-    Date.UTC(
-      nowUTC.getUTCFullYear(),
-      nowUTC.getUTCMonth(),
-      nowUTC.getUTCDate(),
-      0, // hour
-      15, // minute
-      0, // second
-      0, // millisecond
-    ),
-  ).getTime();
-
-  // If we've already passed today's scheduled time, schedule for tomorrow
-  if (now >= nextScheduled) {
-    nextScheduled += 1 * 60 * 60 * 1000;
-  }*/
-
-  // During alpha, sechedule update an hour from now
-  const now = Date.now();
-  const nextScheduled = now + 60 * 60 * 1000;
-
-  const delay = nextScheduled - now;
-  console.log(
-    `[webcat] Scheduling next update in ${Math.round(delay / 1000 / 60)} minutes`,
-  );
-
   scheduledUpdateTimer = setTimeout(async () => {
-    console.log("[webcat] Running scheduled daily update");
     try {
-      await update(db, endpoint);
-    } catch (error) {
-      console.error("[webcat] Scheduled update failed:", error);
+      const lastUpdated = await db.getLastUpdated();
+      if (
+        lastUpdated === null ||
+        Date.now() - lastUpdated >= UPDATE_INTERVAL_MS
+      ) {
+        console.log("[webcat] Running scheduled update (wall-clock check)");
+        try {
+          await update(db, endpoint);
+        } catch (error) {
+          console.error("[webcat] Scheduled update failed:", error);
+        }
+      }
+    } finally {
+      // Always re-schedule the next check
+      scheduleNextUpdate(db, endpoint);
     }
-    // Schedule the next one
-    scheduleNextUpdate(db, endpoint);
-  }, delay) as unknown as number;
+  }, CHECK_INTERVAL_MS) as unknown as number;
 }
 
 // Check and run update if needed

--- a/extension/src/webcat/update.ts
+++ b/extension/src/webcat/update.ts
@@ -7,15 +7,19 @@ import {
   WebcatLeavesFile,
 } from "@freedomofpress/ics23/dist/webcat";
 
+import {
+  CHECK_INTERVAL_MS,
+  FETCH_TIMEOUT_MS,
+  UPDATE_INTERVAL_MS,
+} from "../config";
 import validator_set from "../validator_set.json";
 import { WebcatDatabase } from "./db";
 import { hexToUint8Array, Uint8ArrayToBase64 } from "./encoding";
 import { arraysEqual } from "./utils";
 
 let lastUpdateFailed = false;
-const FETCH_TIMEOUT_MS = 3000; // 3 second timeout for fetches
 
-let scheduledUpdateTimer: number | null = null;
+const ALARM_NAME = "webcat-scheduled-update";
 
 // Helper function to fetch with timeout
 async function fetchWithTimeout(
@@ -41,41 +45,43 @@ async function fetchWithTimeout(
   }
 }
 
-// During alpha, update every hour. Wall-clock based so that sleep/suspend
-// doesn't silently postpone updates.
-export const UPDATE_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
-export const CHECK_INTERVAL_MS = 5 * 60 * 1000; // poll every 5 minutes
-
 // Check if we should do an update at startup (overdue check)
 export function shouldDoScheduledUpdate(lastUpdated: number | null): boolean {
   return lastUpdated === null || Date.now() - lastUpdated >= UPDATE_INTERVAL_MS;
 }
 
-// Start the wall-clock polling loop for scheduled updates.
-function scheduleNextUpdate(db: WebcatDatabase, endpoint: string): void {
-  if (scheduledUpdateTimer !== null) {
-    clearTimeout(scheduledUpdateTimer);
-  }
-
-  scheduledUpdateTimer = setTimeout(async () => {
-    try {
-      const lastUpdated = await db.getLastUpdated();
-      if (
-        lastUpdated === null ||
-        Date.now() - lastUpdated >= UPDATE_INTERVAL_MS
-      ) {
-        console.log("[webcat] Running scheduled update (wall-clock check)");
-        try {
-          await update(db, endpoint);
-        } catch (error) {
-          console.error("[webcat] Scheduled update failed:", error);
-        }
+// Handle the alarm firing: check if an update is due and run it
+export async function handleUpdateAlarm(
+  db: WebcatDatabase,
+  endpoint: string,
+): Promise<void> {
+  try {
+    const lastUpdated = await db.getLastUpdated();
+    if (
+      lastUpdated === null ||
+      Date.now() - lastUpdated >= UPDATE_INTERVAL_MS
+    ) {
+      console.log("[webcat] Running scheduled update (alarm check)");
+      try {
+        await update(db, endpoint);
+      } catch (error) {
+        console.error("[webcat] Scheduled update failed:", error);
       }
-    } finally {
-      // Always re-schedule the next check
-      scheduleNextUpdate(db, endpoint);
     }
-  }, CHECK_INTERVAL_MS) as unknown as number;
+  } catch (error) {
+    console.error("[webcat] Error in update alarm handler:", error);
+  }
+}
+
+// Create a periodic alarm for update checks (works in both MV2 and MV3).
+async function ensureUpdateAlarm(): Promise<void> {
+  const existing = await browser.alarms.get(ALARM_NAME);
+  if (!existing) {
+    browser.alarms.create(ALARM_NAME, {
+      periodInMinutes: CHECK_INTERVAL_MS / 60000,
+    });
+    console.log("[webcat] Created update alarm");
+  }
 }
 
 // Check and run update if needed
@@ -122,6 +128,9 @@ export async function update(
 
     const leavesResponse = fetchWithTimeout(leavesUrl);
     const blockResponse = fetchWithTimeout(blocksUrl);
+
+    // Prevent unhandled rejection if block fetch fails before leaves is awaited
+    leavesResponse.catch(() => {});
 
     // 2 Await latest block
     const block = await (await blockResponse).json();
@@ -193,10 +202,14 @@ export async function initializeScheduledUpdates(
   endpoint: string,
 ): Promise<void> {
   // Check if we need to update now
-  await checkAndUpdate(db, endpoint);
+  try {
+    await checkAndUpdate(db, endpoint);
+  } catch (error) {
+    console.error("[webcat] Error during startup update check:", error);
+  }
 
-  // Schedule future updates
-  scheduleNextUpdate(db, endpoint);
+  // Ensure the periodic alarm exists for future checks
+  await ensureUpdateAlarm();
 }
 
 // Public API: Try to update if last one failed (call on main_frame navigation)

--- a/extension/tests/webcat/update.test.ts
+++ b/extension/tests/webcat/update.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  shouldDoScheduledUpdate,
+  UPDATE_INTERVAL_MS,
+} from "../../src/webcat/update";
+
+describe("shouldDoScheduledUpdate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns true when lastUpdated is null (never updated)", () => {
+    expect(shouldDoScheduledUpdate(null)).toBe(true);
+  });
+
+  it("returns true when lastUpdated is exactly UPDATE_INTERVAL_MS ago", () => {
+    const now = Date.now();
+    expect(shouldDoScheduledUpdate(now - UPDATE_INTERVAL_MS)).toBe(true);
+  });
+
+  it("returns true when lastUpdated is older than UPDATE_INTERVAL_MS", () => {
+    const now = Date.now();
+    expect(shouldDoScheduledUpdate(now - UPDATE_INTERVAL_MS - 1)).toBe(true);
+  });
+
+  it("returns false when lastUpdated is less than UPDATE_INTERVAL_MS ago", () => {
+    const now = Date.now();
+    expect(shouldDoScheduledUpdate(now - UPDATE_INTERVAL_MS + 1)).toBe(false);
+  });
+
+  it("returns false when lastUpdated is very recent", () => {
+    const now = Date.now();
+    expect(shouldDoScheduledUpdate(now - 1000)).toBe(false);
+  });
+
+  it("returns false when lastUpdated is now", () => {
+    const now = Date.now();
+    expect(shouldDoScheduledUpdate(now)).toBe(false);
+  });
+
+  it("returns true after time advances past the interval", () => {
+    const baseTime = Date.now();
+    const lastUpdated = baseTime;
+
+    // Just updated, should not need update
+    expect(shouldDoScheduledUpdate(lastUpdated)).toBe(false);
+
+    // Advance time by 59 minutes, still should not need update
+    vi.advanceTimersByTime(59 * 60 * 1000);
+    expect(shouldDoScheduledUpdate(lastUpdated)).toBe(false);
+
+    // Advance time by 1 more minute (total 60 min), now should need update
+    vi.advanceTimersByTime(1 * 60 * 1000);
+    expect(shouldDoScheduledUpdate(lastUpdated)).toBe(true);
+  });
+});

--- a/extension/tests/webcat/update.test.ts
+++ b/extension/tests/webcat/update.test.ts
@@ -1,9 +1,99 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { CHECK_INTERVAL_MS, UPDATE_INTERVAL_MS } from "../../src/config";
 import {
+  handleUpdateAlarm,
+  initializeScheduledUpdates,
+  retryUpdateIfFailed,
   shouldDoScheduledUpdate,
-  UPDATE_INTERVAL_MS,
+  update,
 } from "../../src/webcat/update";
+
+// Mock the heavy crypto dependencies
+vi.mock("@freedomofpress/cometbft/dist/commit", () => ({
+  importCommit: vi.fn(() => ({ header: {} })),
+}));
+
+vi.mock("@freedomofpress/cometbft/dist/lightclient", () => ({
+  verifyCommit: vi.fn(() => ({
+    ok: true,
+    appHash: new Uint8Array([1, 2, 3]),
+    headerTime: { seconds: 1000n },
+  })),
+}));
+
+vi.mock("@freedomofpress/cometbft/dist/validators", () => ({
+  importValidators: vi.fn(() => ({
+    proto: {},
+    cryptoIndex: {},
+  })),
+}));
+
+vi.mock("@freedomofpress/ics23/dist/webcat", () => ({
+  verifyWebcatProof: vi.fn(() => [["example.com", "abc123"]]),
+}));
+
+vi.mock("../../src/webcat/encoding", () => ({
+  hexToUint8Array: vi.fn(() => new Uint8Array([1, 2, 3])),
+  Uint8ArrayToBase64: vi.fn(() => "AQID"),
+}));
+
+vi.mock("../../src/webcat/utils", () => ({
+  arraysEqual: vi.fn(() => true),
+}));
+
+// Mock the validator set import
+vi.mock("../../src/validator_set.json", () => ({
+  default: {},
+}));
+
+// Mock browser.alarms API
+const mockAlarms = {
+  get: vi.fn(),
+  create: vi.fn(),
+};
+(globalThis as Record<string, unknown>).browser = {
+  alarms: mockAlarms,
+  runtime: {
+    getURL: vi.fn((path: string) => `moz-extension://test-id/${path}`),
+  },
+};
+
+// Create a mock database
+function createMockDb() {
+  return {
+    setLastChecked: vi.fn(),
+    setLastUpdated: vi.fn(),
+    getLastUpdated: vi.fn(),
+    getLastBlockTime: vi.fn(),
+    setLastBlockTime: vi.fn(),
+    setRootHash: vi.fn(),
+    updateList: vi.fn(),
+  };
+}
+
+// Create a mock fetch that returns valid block and leaves responses
+function setupFetchMock() {
+  const blockJson = { height: "100", commit: {} };
+  const leavesJson = {
+    proof: {
+      app_hash: "010203",
+      canonical_root_hash: "aabbcc",
+    },
+    leaves: [],
+  };
+
+  globalThis.fetch = vi.fn((url: string) => {
+    const body = (url as string).includes("block.json")
+      ? blockJson
+      : leavesJson;
+    return Promise.resolve({
+      json: () => Promise.resolve(body),
+    } as Response);
+  });
+
+  return { blockJson, leavesJson };
+}
 
 describe("shouldDoScheduledUpdate", () => {
   beforeEach(() => {
@@ -57,5 +147,272 @@ describe("shouldDoScheduledUpdate", () => {
     // Advance time by 1 more minute (total 60 min), now should need update
     vi.advanceTimersByTime(1 * 60 * 1000);
     expect(shouldDoScheduledUpdate(lastUpdated)).toBe(true);
+  });
+});
+
+describe("update", () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    db.getLastBlockTime.mockResolvedValue(null);
+    setupFetchMock();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches from the network endpoint when bundled is false", async () => {
+    await update(db as never, "https://example.com/");
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://example.com/list.json",
+      expect.any(Object),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://example.com/block.json",
+      expect.any(Object),
+    );
+  });
+
+  it("fetches from bundled URLs when bundled is true", async () => {
+    await update(db as never, "https://example.com/", true);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "moz-extension://test-id/data/list.json",
+      expect.any(Object),
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "moz-extension://test-id/data/block.json",
+      expect.any(Object),
+    );
+  });
+
+  it("calls setLastUpdated only for non-bundled updates", async () => {
+    await update(db as never, "https://example.com/", false);
+    expect(db.setLastUpdated).toHaveBeenCalled();
+
+    db.setLastUpdated.mockClear();
+    await update(db as never, "https://example.com/", true);
+    expect(db.setLastUpdated).not.toHaveBeenCalled();
+  });
+
+  it("always calls setLastChecked", async () => {
+    await update(db as never, "https://example.com/", true);
+    expect(db.setLastChecked).toHaveBeenCalled();
+
+    db.setLastChecked.mockClear();
+    await update(db as never, "https://example.com/", false);
+    expect(db.setLastChecked).toHaveBeenCalled();
+  });
+
+  it("updates the list and block time on success", async () => {
+    await update(db as never, "https://example.com/");
+
+    expect(db.updateList).toHaveBeenCalledWith([["example.com", "abc123"]]);
+    expect(db.setLastBlockTime).toHaveBeenCalledWith(1000n);
+    expect(db.setRootHash).toHaveBeenCalledWith("aabbcc");
+  });
+
+  it("skips update when block is already applied", async () => {
+    // Block time from verifyCommit mock returns 1000n
+    db.getLastBlockTime.mockResolvedValue(1000n);
+
+    await update(db as never, "https://example.com/");
+
+    expect(db.updateList).not.toHaveBeenCalled();
+    expect(db.setLastBlockTime).not.toHaveBeenCalled();
+  });
+
+  it("throws and sets failure flag on block verification failure", async () => {
+    const { verifyCommit } =
+      await import("@freedomofpress/cometbft/dist/lightclient");
+    (verifyCommit as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+    });
+
+    await expect(update(db as never, "https://example.com/")).rejects.toThrow(
+      "Block verification failed",
+    );
+  });
+
+  it("throws when app_hash mismatches", async () => {
+    const { arraysEqual } = await import("../../src/webcat/utils");
+    (arraysEqual as ReturnType<typeof vi.fn>).mockReturnValueOnce(false);
+
+    await expect(update(db as never, "https://example.com/")).rejects.toThrow(
+      "app hash mismatch",
+    );
+  });
+
+  it("throws when proof verification fails", async () => {
+    const { verifyWebcatProof } =
+      await import("@freedomofpress/ics23/dist/webcat");
+    (verifyWebcatProof as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      false,
+    );
+
+    await expect(update(db as never, "https://example.com/")).rejects.toThrow(
+      "proof did not verify",
+    );
+  });
+});
+
+describe("handleUpdateAlarm", () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    setupFetchMock();
+    db.getLastBlockTime.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("runs update when lastUpdated is null", async () => {
+    db.getLastUpdated.mockResolvedValue(null);
+
+    await handleUpdateAlarm(db as never, "https://example.com/");
+
+    expect(db.updateList).toHaveBeenCalled();
+  });
+
+  it("runs update when update interval has elapsed", async () => {
+    db.getLastUpdated.mockResolvedValue(Date.now() - UPDATE_INTERVAL_MS - 1000);
+
+    await handleUpdateAlarm(db as never, "https://example.com/");
+
+    expect(db.updateList).toHaveBeenCalled();
+  });
+
+  it("skips update when interval has not elapsed", async () => {
+    db.getLastUpdated.mockResolvedValue(Date.now() - 1000);
+
+    await handleUpdateAlarm(db as never, "https://example.com/");
+
+    expect(db.updateList).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when update fails", async () => {
+    db.getLastUpdated.mockResolvedValue(null);
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error("network error")));
+
+    await expect(
+      handleUpdateAlarm(db as never, "https://example.com/"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not throw when db.getLastUpdated fails", async () => {
+    db.getLastUpdated.mockRejectedValue(new Error("db error"));
+
+    await expect(
+      handleUpdateAlarm(db as never, "https://example.com/"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("retryUpdateIfFailed", () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    setupFetchMock();
+    db.getLastBlockTime.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not run update when no prior failure", async () => {
+    // Ensure a successful update first to clear the failure flag
+    db.getLastUpdated.mockResolvedValue(null);
+    await handleUpdateAlarm(db as never, "https://example.com/");
+
+    db.updateList.mockClear();
+    await retryUpdateIfFailed(db as never, "https://example.com/");
+
+    expect(db.updateList).not.toHaveBeenCalled();
+  });
+
+  it("retries update after a prior failure", async () => {
+    // Trigger a failure to set lastUpdateFailed = true
+    db.getLastUpdated.mockResolvedValue(null);
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error("network error")));
+    await handleUpdateAlarm(db as never, "https://example.com/");
+
+    // Now restore fetch and retry
+    setupFetchMock();
+    db.updateList.mockClear();
+    await retryUpdateIfFailed(db as never, "https://example.com/");
+
+    expect(db.updateList).toHaveBeenCalled();
+  });
+
+  it("does not throw when retry itself fails", async () => {
+    // Trigger initial failure
+    db.getLastUpdated.mockResolvedValue(null);
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error("network error")));
+    await handleUpdateAlarm(db as never, "https://example.com/");
+
+    // Retry also fails — should not throw
+    await expect(
+      retryUpdateIfFailed(db as never, "https://example.com/"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("initializeScheduledUpdates", () => {
+  let db: ReturnType<typeof createMockDb>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    setupFetchMock();
+    db.getLastBlockTime.mockResolvedValue(null);
+    mockAlarms.get.mockResolvedValue(undefined);
+    mockAlarms.create.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates the alarm", async () => {
+    db.getLastUpdated.mockResolvedValue(Date.now());
+
+    await initializeScheduledUpdates(db as never, "https://example.com/");
+
+    expect(mockAlarms.create).toHaveBeenCalledWith("webcat-scheduled-update", {
+      periodInMinutes: CHECK_INTERVAL_MS / 60000,
+    });
+  });
+
+  it("does not create a duplicate alarm", async () => {
+    db.getLastUpdated.mockResolvedValue(Date.now());
+    mockAlarms.get.mockResolvedValue({ name: "webcat-scheduled-update" });
+
+    await initializeScheduledUpdates(db as never, "https://example.com/");
+
+    expect(mockAlarms.create).not.toHaveBeenCalled();
+  });
+
+  it("runs an overdue update and creates the alarm", async () => {
+    db.getLastUpdated.mockResolvedValue(null);
+
+    await initializeScheduledUpdates(db as never, "https://example.com/");
+
+    expect(db.updateList).toHaveBeenCalled();
+    expect(mockAlarms.create).toHaveBeenCalled();
+  });
+
+  it("still creates alarm when checkAndUpdate throws", async () => {
+    db.getLastUpdated.mockRejectedValue(new Error("db error"));
+
+    await initializeScheduledUpdates(db as never, "https://example.com/");
+
+    expect(mockAlarms.create).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This PR removes some unused code. Furthermore, currently update logic was setting an interval at the end of which a list update would be attempted again. However, this behaved poorly with situations like sleep or suspending. In those cases, the interval would pause and resume after resume, thus not fetching an update even if many hours have passed.

The new logic checks every 5 minutes wether enough time (using the clock) has passed since the last update check, and in case triggers one. Thus, in case of suspension, only the 5 minute timeout has to be fully awaited. There's also associated tests.

Resolves https://github.com/freedomofpress/webcat/issues/77