### PR TITLE
Hook WASM from content script

### DIFF
--- a/extension/src/globals.ts
+++ b/extension/src/globals.ts
@@ -1,9 +1,13 @@
 import { lru_cache_size, lru_set_size } from "./config";
 import { LRUCache, LRUSet } from "./webcat/cache";
 import { WebcatDatabase } from "./webcat/db";
+import { stringToUint8Array, Uint8ArrayToBase64Url } from "./webcat/encoding";
 import { OriginStateHolder } from "./webcat/interfaces/originstate";
 
 export const origins = new LRUCache<string, OriginStateHolder>(lru_set_size);
 export const nonOrigins = new LRUSet<string>(lru_cache_size);
 export const tabs: Map<number, string> = new Map();
 export const db = new WebcatDatabase("webcat");
+export const hookMarker = stringToUint8Array(
+  `__WEBCAT_HOOK__{${Uint8ArrayToBase64Url(crypto.getRandomValues(new Uint8Array(32)))}}\n`,
+);

--- a/extension/src/webcat/genhooks.ts
+++ b/extension/src/webcat/genhooks.ts
@@ -2,16 +2,18 @@ import contentHooks from "./../../dist/hooks/content.js?raw";
 import pageHooks from "./../../dist/hooks/page.js?raw";
 import { hooksType } from "./interfaces/base";
 
-export function getHooks(type: hooksType, wasm: string[], key: string) {
+export function getHooks(type: hooksType, wasm: string[]) {
   // This just patches the script string dynamically adding per-origin WASM hashes
   if (type === hooksType.page) {
-    return pageHooks
-      .replace('["__HASHES_PLACEHOLDER__"]', JSON.stringify(wasm))
-      .replace("__KEY_PLACEHOLDER__", key);
+    return pageHooks.replace(
+      '["__HASHES_PLACEHOLDER__"]',
+      JSON.stringify(wasm),
+    );
   } else if (type === hooksType.content_script) {
-    return contentHooks
-      .replace('["__HASHES_PLACEHOLDER__"]', JSON.stringify(wasm))
-      .replace("__KEY_PLACEHOLDER__", key);
+    return contentHooks.replace(
+      '["__HASHES_PLACEHOLDER__"]',
+      JSON.stringify(wasm),
+    );
   } else {
     throw new Error(`Unknown hooks type: ${type}`);
   }

--- a/extension/src/webcat/hooks/core.ts
+++ b/extension/src/webcat/hooks/core.ts
@@ -4,27 +4,29 @@
 
 import { SHA256 } from "./sha256";
 
-export function wasmHook() {
-  let wasm: typeof WebAssembly;
-
-  if (typeof window === "undefined") {
-    wasm = globalThis.WebAssembly;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } else if ((window as any).getWebAssemblyPtr) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    wasm = (window as any).getWebAssemblyPtr("__KEY_PLACEHOLDER__");
-  } else {
-    return;
-  }
+// Hook the WebAssembly object in either a content script or a Worker.
+// In a content script, scope must be the the wrapped (Xray vision) window object,
+// unwrappedScope the unwrapped (no Xray vision) window object, and exportFunction the
+// built-in content script exportFunction. In a Worker, scope and unwrappedScope must
+// be globalThis and exportFunction a function that assigns func directly to
+// targetScope[options.defineAs].
+export function wasmHook(
+  scope: typeof globalThis,
+  unwrappedScope: typeof globalThis,
+  baseURI: string,
+  exportFunction: (
+    func: Function, // eslint-disable-line @typescript-eslint/no-unsafe-function-type
+    targetScope: object,
+    options: { defineAs: string },
+  ) => Function, // eslint-disable-line @typescript-eslint/no-unsafe-function-type
+) {
+  const wasm = unwrappedScope.WebAssembly;
 
   // Check if the WebAssembly hook has already been injected.
   if (Object.prototype.hasOwnProperty.call(wasm, "__hooked__")) {
     console.log("[WEBCAT] WebAssembly hook already injected.");
     return;
   }
-
-  // Save the original crypto.subtle.
-  const originalCryptoSubtle: SubtleCrypto = globalThis.crypto.subtle;
 
   // Hardcoded allowlist of allowed SHA-256 hex digests.
   const ALLOWED_HASHES: string[] = ["__HASHES_PLACEHOLDER__"];
@@ -40,24 +42,33 @@ export function wasmHook() {
       .replace(/=+$/, "");
   }
 
-  // Async bytecode verifier: uses crypto.subtle.digest.
-  async function verifyBytecodeAsync(buffer: ArrayBuffer): Promise<void> {
-    const digestBuffer: ArrayBuffer = await originalCryptoSubtle.digest(
-      "SHA-256",
-      buffer,
-    );
-    const hashHex: string = arrayBuffertoBase64Url(digestBuffer);
-    if (!ALLOWED_HASHES.includes(hashHex)) {
-      throw new Error(`[WEBCAT] Unauthorized WebAssembly bytecode: ${hashHex}`);
+  // Async bytecode verifier: uses crypto.subtle.digest. Must always return
+  // a scope.Promise, may never throw.
+  function verifyBytecodeAsync(bufferSource: BufferSource): Promise<void> {
+    try {
+      const buffer = extractBuffer(bufferSource);
+      return crypto.subtle.digest("SHA-256", buffer).then((digestBuffer) => {
+        const hashHex: string = arrayBuffertoBase64Url(digestBuffer);
+        if (!ALLOWED_HASHES.includes(hashHex)) {
+          throw new scope.Error(
+            `[WEBCAT] Unauthorized WebAssembly bytecode: ${hashHex}`,
+          );
+        }
+        console.log(`[WEBCAT] Verified WASM (async) ${hashHex}`);
+      });
+    } catch (e) {
+      return scope.Promise.reject(e);
     }
-    console.log(`[WEBCAT] Verified WASM (async) ${hashHex}`);
   }
 
   // Synchronous bytecode verifier: uses the synchronous SHA256(buffer).
-  function verifyBytecodeSync(buffer: ArrayBuffer): void {
+  function verifyBytecodeSync(bufferSource: BufferSource): void {
+    const buffer = extractBuffer(bufferSource);
     const hashHex: string = arrayBuffertoBase64Url(SHA256(buffer));
     if (!ALLOWED_HASHES.includes(hashHex)) {
-      throw new Error(`[WEBCAT] Unauthorized WebAssembly bytecode: ${hashHex}`);
+      throw new scope.Error(
+        `[WEBCAT] Unauthorized WebAssembly bytecode: ${hashHex}`,
+      );
     }
     console.log(`[WEBCAT] Verified WASM (sync) ${hashHex}`);
   }
@@ -66,13 +77,13 @@ export function wasmHook() {
   function extractBuffer(
     bufferSource: BufferSource | WebAssembly.Module,
   ): ArrayBuffer {
-    if (bufferSource instanceof ArrayBuffer) {
+    if (bufferSource instanceof scope.ArrayBuffer) {
       return bufferSource;
     }
-    if (ArrayBuffer.isView(bufferSource)) {
+    if (scope.ArrayBuffer.isView(bufferSource)) {
       return bufferSource.buffer as ArrayBuffer;
     }
-    throw new TypeError(
+    throw new scope.TypeError(
       "[WEBCAT] WebAssembly bytecode must be provided as an ArrayBuffer or typed array",
     );
   }
@@ -81,109 +92,95 @@ export function wasmHook() {
   // Hooking WebAssembly Methods
   // ============================
 
-  //
   // Hook WebAssembly.instantiate (async)
-  //
   const originalInstantiate = wasm.instantiate;
-  // Overloads for WebAssembly.instantiate.
   function hookedInstantiate(
-    source: WebAssembly.Module,
+    this: typeof WebAssembly,
+    source: WebAssembly.Module | BufferSource,
     importObject?: WebAssembly.Imports,
-  ): Promise<WebAssembly.Instance>;
-  function hookedInstantiate(
-    source: BufferSource | Promise<BufferSource>,
-    importObject?: WebAssembly.Imports,
-  ): Promise<WebAssembly.WebAssemblyInstantiatedSource>;
-  async function hookedInstantiate(
-    this: unknown,
-    source: WebAssembly.Module | BufferSource | Promise<BufferSource>,
-    importObject?: WebAssembly.Imports,
+    compileOptions?: object,
   ): Promise<unknown> {
     // If the source is already a compiled module, bypass verification.
     if (source instanceof wasm.Module) {
-      return originalInstantiate.call(this, source, importObject);
+      return originalInstantiate.call(
+        this,
+        source,
+        importObject,
+        compileOptions,
+      );
     } else {
-      // If source is a Promise, await it.
-      const sourceBuffer:
-        | WebAssembly.Module
-        | BufferSource
-        | Promise<BufferSource> =
-        source instanceof Promise ? await source : source;
-      const buffer: ArrayBuffer = extractBuffer(sourceBuffer);
-      try {
-        await verifyBytecodeAsync(buffer);
-      } catch (e) {
-        return Promise.reject(e);
-      }
-      return originalInstantiate.call(this, sourceBuffer, importObject);
+      return verifyBytecodeAsync(source).then(
+        originalInstantiate.bind(this, source, importObject, compileOptions),
+      );
     }
   }
-  wasm.instantiate = hookedInstantiate as typeof WebAssembly.instantiate;
+  exportFunction(hookedInstantiate, wasm, { defineAs: "instantiate" });
 
-  //
   // Hook WebAssembly.compile (async)
-  //
   const originalCompile = wasm.compile;
-  wasm.compile = async function (
+  function hookedCompile(
     this: typeof wasm,
     bufferSource: BufferSource,
+    compileOptions?: object,
   ): Promise<WebAssembly.Module> {
-    try {
-      const buffer: ArrayBuffer = extractBuffer(bufferSource);
-      await verifyBytecodeAsync(buffer);
-    } catch (e) {
-      return Promise.reject(e);
-    }
-    return originalCompile.call(this, bufferSource);
-  };
+    return verifyBytecodeAsync(bufferSource).then(
+      originalCompile.bind(this, bufferSource, compileOptions),
+    );
+  }
+  exportFunction(hookedCompile, wasm, { defineAs: "compile" });
 
-  //
   // Hook WebAssembly.validate (synchronous)
-  //
   const originalValidate = wasm.validate;
-  wasm.validate = function (
+  function hookedValidate(
     this: typeof wasm,
     bufferSource: BufferSource,
   ): boolean {
-    const buffer: ArrayBuffer = extractBuffer(bufferSource);
-    verifyBytecodeSync(buffer);
+    verifyBytecodeSync(bufferSource);
     return originalValidate.call(this, bufferSource);
-  };
+  }
+  exportFunction(hookedValidate, wasm, { defineAs: "validate" });
 
-  //
   // Hook WebAssembly.instantiateStreaming (async)
-  //
   const originalInstantiateStreaming = wasm.instantiateStreaming;
-  wasm.instantiateStreaming = async function (
+  function hookedInstantiateStreaming(
     this: typeof wasm,
-    responseOrPromise: Response | PromiseLike<Response>,
+    source: Response | PromiseLike<Response>,
     importObject?: WebAssembly.Imports,
+    compileOptions?: object,
   ): Promise<WebAssembly.WebAssemblyInstantiatedSource> {
-    const response: Response = await Promise.resolve(responseOrPromise);
-    const clonedResponse: Response = response.clone();
-    const buffer: ArrayBuffer = await clonedResponse.arrayBuffer();
-    await verifyBytecodeAsync(buffer);
-    return originalInstantiateStreaming.call(this, response, importObject);
-  };
+    return scope.Promise.resolve(source)
+      .then((response) => response.clone().arrayBuffer())
+      .then(verifyBytecodeAsync)
+      .then(
+        originalInstantiateStreaming.bind(
+          this,
+          source,
+          importObject,
+          compileOptions,
+        ),
+      );
+  }
+  exportFunction(hookedInstantiateStreaming, wasm, {
+    defineAs: "instantiateStreaming",
+  });
 
-  //
   // Hook WebAssembly.compileStreaming (async)
-  //
   const originalCompileStreaming = wasm.compileStreaming;
-  wasm.compileStreaming = async function (
+  function hookedCompileStreaming(
     this: typeof wasm,
-    responseOrPromise: Response | PromiseLike<Response>,
+    source: Response | PromiseLike<Response>,
+    compileOptions?: object,
   ): Promise<WebAssembly.Module> {
-    const response: Response = await Promise.resolve(responseOrPromise);
-    const clonedResponse: Response = response.clone();
-    const buffer: ArrayBuffer = await clonedResponse.arrayBuffer();
-    await verifyBytecodeAsync(buffer);
-    return originalCompileStreaming.call(this, response);
-  };
+    return scope.Promise.resolve(source)
+      .then((response) => response.clone().arrayBuffer())
+      .then(verifyBytecodeAsync)
+      .then(originalCompileStreaming.bind(this, source, compileOptions));
+  }
+  exportFunction(hookedCompileStreaming, wasm, {
+    defineAs: "compileStreaming",
+  });
 
-  //
   // Hook the WebAssembly.Module constructor (synchronous)
-  //
   type WebAssemblyModuleConstructor = {
     new (bytes: BufferSource): WebAssembly.Module;
     prototype: WebAssembly.Module;
@@ -201,7 +198,6 @@ export function wasmHook() {
 
   // Hook the WebAssembly.Module constructor (synchronous)
   const OriginalModule = wasm.Module;
-
   function HookedModule(
     this: object,
     bufferSource: BufferSource,
@@ -211,25 +207,31 @@ export function wasmHook() {
         "[WEBCAT] Constructor WebAssembly.Module requires 'new'",
       );
     }
-    const buffer: ArrayBuffer = extractBuffer(bufferSource);
-    verifyBytecodeSync(buffer);
+    verifyBytecodeSync(bufferSource);
     return new OriginalModule(bufferSource);
   }
-
-  // Set up the prototype.
-  HookedModule.prototype = OriginalModule.prototype;
-
-  // Cast HookedModule to our complete constructor type.
   const hookedModule = HookedModule as unknown as WebAssemblyModuleConstructor;
-
-  // Now assign the static methods.
   hookedModule.customSections =
     OriginalModule.customSections.bind(OriginalModule);
   hookedModule.exports = OriginalModule.exports.bind(OriginalModule);
   hookedModule.imports = OriginalModule.imports.bind(OriginalModule);
+  exportFunction(hookedModule, wasm, { defineAs: "Module" });
+  wasm.Module.prototype = OriginalModule.prototype;
 
-  // Finally, assign the hooked constructor to WebAssembly.Module.
-  wasm.Module = hookedModule as typeof wasm.Module;
+  // Hook Worker to mark worker scripts for further hooking
+  if ("Worker" in unwrappedScope) {
+    const OriginalWorker = unwrappedScope.Worker;
+    function HookedWorker(this: object, url: string, options: object) {
+      if (!(this instanceof HookedWorker)) {
+        throw new TypeError("[WEBCAT] Constructor Worker requires 'new'");
+      }
+      const parsedUrl = new URL(url, baseURI);
+      parsedUrl.hash = "#__WEBCAT_hooked_worker__";
+      return new OriginalWorker(parsedUrl.toString(), options);
+    }
+    exportFunction(HookedWorker, unwrappedScope, { defineAs: "Worker" });
+    unwrappedScope.Worker.prototype = OriginalWorker.prototype;
+  }
 
   // Mark WebAssembly as hooked.
   Object.defineProperty(wasm, "__hooked__", {
@@ -238,8 +240,6 @@ export function wasmHook() {
     configurable: false,
     enumerable: false,
   });
-
-  globalThis.WebAssembly = wasm;
 
   console.log(
     "[WEBCAT] WebAssembly successfully hooked: all bytecode entry points now require authorization.",

--- a/extension/src/webcat/hooks/core.ts
+++ b/extension/src/webcat/hooks/core.ts
@@ -218,21 +218,6 @@ export function wasmHook(
   exportFunction(hookedModule, wasm, { defineAs: "Module" });
   wasm.Module.prototype = OriginalModule.prototype;
 
-  // Hook Worker to mark worker scripts for further hooking
-  if ("Worker" in unwrappedScope) {
-    const OriginalWorker = unwrappedScope.Worker;
-    function HookedWorker(this: object, url: string, options: object) {
-      if (!(this instanceof HookedWorker)) {
-        throw new TypeError("[WEBCAT] Constructor Worker requires 'new'");
-      }
-      const parsedUrl = new URL(url, baseURI);
-      parsedUrl.hash = "#__WEBCAT_hooked_worker__";
-      return new OriginalWorker(parsedUrl.toString(), options);
-    }
-    exportFunction(HookedWorker, unwrappedScope, { defineAs: "Worker" });
-    unwrappedScope.Worker.prototype = OriginalWorker.prototype;
-  }
-
   // Mark WebAssembly as hooked.
   Object.defineProperty(wasm, "__hooked__", {
     value: true,

--- a/extension/src/webcat/hooks/entry-content.ts
+++ b/extension/src/webcat/hooks/entry-content.ts
@@ -1,15 +1,5 @@
+import { wasmHook } from "./core";
+
 console.log("[WEBCAT] Installing content script hook");
 
-const pageWin = window.wrappedJSObject;
-const wasm = pageWin.WebAssembly;
-
-function getWebAssemblyPtr(pwd: string) {
-  const key = "__KEY_PLACEHOLDER__";
-  if (pwd === key) {
-    return wasm;
-  }
-}
-
-exportFunction(getWebAssemblyPtr, pageWin, { defineAs: "getWebAssemblyPtr" });
-
-delete pageWin.WebAssembly;
+wasmHook(window, window.wrappedJSObject, document.baseURI, exportFunction);

--- a/extension/src/webcat/hooks/entry-page.ts
+++ b/extension/src/webcat/hooks/entry-page.ts
@@ -2,4 +2,12 @@ import { wasmHook } from "./core";
 
 console.log("[WEBCAT] Installing page hook");
 
-wasmHook();
+wasmHook(
+  globalThis,
+  globalThis,
+  location.href,
+  (func, targetScope, { defineAs }) => {
+    Object.defineProperty(targetScope, defineAs, { value: func });
+    return func;
+  },
+);

--- a/extension/src/webcat/interfaces/originstate.ts
+++ b/extension/src/webcat/interfaces/originstate.ts
@@ -1,7 +1,7 @@
 import { bundle_name, bundle_prev_name } from "../../config";
 import { db } from "../../globals";
 import { canonicalize } from "../canonicalize";
-import { stringToUint8Array, Uint8ArrayToBase64Url } from "../encoding";
+import { stringToUint8Array } from "../encoding";
 import { headersListener, requestListener } from "../listeners";
 import { arraysEqual } from "../utils";
 import { SHA256 } from "../utils";
@@ -140,7 +140,6 @@ export abstract class OriginStateBase {
   public readonly valid_signers?: Set<string>;
   public readonly valid_sources?: Set<string>;
   public readonly delegation?: string;
-  public readonly hooks_key: string;
 
   // Per origin function wrappers: the extension API does not support registering
   // the same listener multiple times with different rules. We thus want a wrapper
@@ -168,9 +167,6 @@ export abstract class OriginStateBase {
     this.enrollment_hash = enrollment_hash;
     this.references = 1;
 
-    const bytes = new Uint8Array(32);
-    crypto.getRandomValues(bytes);
-    this.hooks_key = Uint8ArrayToBase64Url(bytes);
     this.onBeforeRequest = (details) => requestListener(details);
     this.onHeadersReceived = (details) => headersListener(details);
 

--- a/extension/src/webcat/interfaces/originstate.ts
+++ b/extension/src/webcat/interfaces/originstate.ts
@@ -2,7 +2,11 @@ import { bundle_name, bundle_prev_name } from "../../config";
 import { db } from "../../globals";
 import { canonicalize } from "../canonicalize";
 import { stringToUint8Array } from "../encoding";
-import { headersListener, requestListener } from "../listeners";
+import {
+  beforeHeadersListener,
+  headersListener,
+  requestListener,
+} from "../listeners";
 import { arraysEqual } from "../utils";
 import { SHA256 } from "../utils";
 import { validateCSP, validateSigstoreEnrollment } from "../validators";
@@ -114,6 +118,9 @@ export class OriginStateHolder {
     browser.webRequest.onBeforeRequest.removeListener(
       this.current.onBeforeRequest,
     );
+    browser.webRequest.onBeforeSendHeaders.removeListener(
+      this.current.onBeforeSendHeaders,
+    );
     browser.webRequest.onHeadersReceived.removeListener(
       this.current.onHeadersReceived,
     );
@@ -147,6 +154,9 @@ export abstract class OriginStateBase {
   public onBeforeRequest: (
     details: browser.webRequest._OnBeforeRequestDetails,
   ) => Promise<browser.webRequest.BlockingResponse>;
+  public onBeforeSendHeaders: (
+    details: browser.webRequest._OnBeforeSendHeadersDetails,
+  ) => Promise<browser.webRequest.BlockingResponse>;
   public onHeadersReceived: (
     details: browser.webRequest._OnHeadersReceivedDetails,
   ) => Promise<browser.webRequest.BlockingResponse>;
@@ -168,6 +178,7 @@ export abstract class OriginStateBase {
     this.references = 1;
 
     this.onBeforeRequest = (details) => requestListener(details);
+    this.onBeforeSendHeaders = (details) => beforeHeadersListener(details);
     this.onHeadersReceived = (details) => headersListener(details);
 
     // Cleanup service workers, see https://github.com/freedomofpress/webcat/issues/18
@@ -336,6 +347,7 @@ export class OriginStateVerifiedEnrollment extends OriginStateBase {
       prev.enrollment_hash,
     );
     this.onBeforeRequest = prev.onBeforeRequest;
+    this.onBeforeSendHeaders = prev.onBeforeSendHeaders;
     this.onHeadersReceived = prev.onHeadersReceived;
     this.references = prev.references;
     this.enrollment = enrollment;
@@ -459,6 +471,7 @@ export class OriginStateVerifiedManifest extends OriginStateBase {
       prev.enrollment_hash,
     );
     this.onBeforeRequest = prev.onBeforeRequest;
+    this.onBeforeSendHeaders = prev.onBeforeSendHeaders;
     this.onHeadersReceived = prev.onHeadersReceived;
     this.references = prev.references;
     this.enrollment = prev.enrollment;

--- a/extension/src/webcat/listeners.ts
+++ b/extension/src/webcat/listeners.ts
@@ -143,7 +143,6 @@ export async function headersListener(
     originStateHolder.current.manifest
   ) {
     const wasm = originStateHolder.current.manifest.wasm;
-    const hooks_key = originStateHolder.current.hooks_key;
 
     const listener = async (
       navDetails: browser.webNavigation._OnCommittedDetails,
@@ -154,7 +153,7 @@ export async function headersListener(
       browser.webNavigation.onCommitted.removeListener(listener);
 
       await browser.tabs.executeScript(details.tabId, {
-        code: getHooks(hooksType.content_script, wasm, hooks_key),
+        code: getHooks(hooksType.content_script, wasm),
         runAt: "document_start",
         frameId: details.frameId,
       });

--- a/extension/src/webcat/listeners.ts
+++ b/extension/src/webcat/listeners.ts
@@ -6,7 +6,11 @@ import { WebcatError } from "./interfaces/errors";
 import { logger } from "./logger";
 import { validateOrigin } from "./request";
 import { FRAME_TYPES } from "./resources";
-import { validateResponseContent, validateResponseHeaders } from "./response";
+import {
+  hookResponseContent,
+  validateResponseContent,
+  validateResponseHeaders,
+} from "./response";
 import { errorpage } from "./ui";
 import { retryUpdateIfFailed } from "./update";
 import { getFQDN, isExtensionRequest } from "./utils";
@@ -162,6 +166,31 @@ export async function headersListener(
     browser.webNavigation.onCommitted.addListener(listener);
   }
 
+  return {};
+}
+
+export async function beforeHeadersListener(
+  details: browser.webRequest._OnBeforeSendHeadersDetails,
+): Promise<browser.webRequest.BlockingResponse> {
+  // this listener is only added for script requests, i.e.
+  // here we already know details.type === "script"
+  if (!details.requestHeaders) {
+    console.error("FATAL: request headers not available");
+    return { cancel: true };
+  }
+  for (const header of details.requestHeaders) {
+    if (header.name.toLowerCase() === "sec-fetch-dest") {
+      switch (header.value) {
+        case "worker":
+        case "serviceworker":
+        case "sharedworker":
+        case "audioworklet":
+        case "paintworklet":
+          await hookResponseContent(details);
+      }
+      break;
+    }
+  }
   return {};
 }
 

--- a/extension/src/webcat/request.ts
+++ b/extension/src/webcat/request.ts
@@ -90,6 +90,15 @@ export async function validateOrigin(
     ["blocking"],
   );
 
+  browser.webRequest.onBeforeSendHeaders.addListener(
+    origin.current.onBeforeSendHeaders,
+    {
+      urls: [`http://${fqdn}/*`, `https://${fqdn}/*`],
+      types: ["script"],
+    },
+    ["blocking", "requestHeaders"],
+  );
+
   browser.webRequest.onHeadersReceived.addListener(
     origin.current.onHeadersReceived,
     {

--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -1,4 +1,4 @@
-import { origins } from "./../globals";
+import { hookMarker, origins } from "./../globals";
 import {
   base64UrlToUint8Array,
   stringToUint8Array,
@@ -7,7 +7,7 @@ import {
 } from "./encoding";
 import { getHooks } from "./genhooks";
 import { hooksType } from "./interfaces/base";
-import { Enrollment } from "./interfaces/bundle";
+import { Enrollment, Manifest } from "./interfaces/bundle";
 import { WebcatError, WebcatErrorCode } from "./interfaces/errors";
 import {
   OriginStateFailed,
@@ -228,23 +228,31 @@ export async function validateResponseContent(
     }
   }
 
+  let originStateHolder: OriginStateHolder;
+  let manifest: Manifest;
   const filter = browser.webRequest.filterResponseData(details.requestId);
+  filter.onstart = () => {
+      originStateHolder = getVerifiedManifestState(fqdn);
+      manifest = (originStateHolder.current as OriginStateVerifiedManifest)
+        .manifest;
+  }
 
   const source: ArrayBuffer[] = [];
   filter.ondata = (event: { data: ArrayBuffer }) => {
     // The data here is usually chunked; normally it would be streamed down as we get it
     // but since we can hash the content only at the end, we have to wait until we have everything
     // before deciding if the response content matches the manifest or not. So we are saving it and we will
-    // build a blob later
-    source.push(event.data);
+    // build a blob later. If the data is the hook marker, we immediately inject the WASM hooks instead.
+    if (arraysEqual(hookMarker, new Uint8Array(event.data))) {
+      const hooks = getHooks(hooksType.page, manifest.wasm);
+      filter.write(stringToUint8Array(hooks));
+    } else {
+      source.push(event.data);
+    }
   };
 
   filter.onstop = async () => {
-    const originStateHolder = getVerifiedManifestState(fqdn);
     const blob = await new Blob(source).arrayBuffer();
-
-    const manifest = (originStateHolder.current as OriginStateVerifiedManifest)
-      .manifest;
 
     // Following order of priority:
     // - If there's an exact match, that should be the hash
@@ -294,16 +302,6 @@ export async function validateResponseContent(
     // If everything is OK then we can just write the raw blob back
     logger.addLog("info", `${pathname} verified.`, details.tabId, fqdn);
 
-    if (
-      details.type === "script" &&
-      (details.tabId < 0 || // is this a ServiceWorker or a SharedWorker?
-        details.url.endsWith("#__WEBCAT_hooked_worker__")) // ...or a dedicated Worker?
-    ) {
-      // Inject the WASM hooks
-      const hooks = getHooks(hooksType.page, manifest.wasm);
-      filter.write(stringToUint8Array(hooks));
-    }
-
     filter.write(blob);
     // close() ensures that nothing can be added afterwards; disconnect() just stops the filter and not the response
     // see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter
@@ -312,5 +310,17 @@ export async function validateResponseContent(
       setOKIcon(details.tabId, originStateHolder.current.delegation);
     }
     // Redirect the main frame to an error page
+  };
+}
+
+export async function hookResponseContent(
+  details: browser.webRequest._OnBeforeSendHeadersDetails,
+) {
+  const filter = browser.webRequest.filterResponseData(details.requestId);
+  filter.onstart = () => {
+    // insert hook marker, later replaced with
+    // the actual hook in the validation filter
+    filter.write(hookMarker);
+    filter.disconnect();
   };
 }

--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -294,14 +294,13 @@ export async function validateResponseContent(
     // If everything is OK then we can just write the raw blob back
     logger.addLog("info", `${pathname} verified.`, details.tabId, fqdn);
 
-    if (details.type === "script") {
-      // Inject the WASM hooks in every loaded script.
-
-      const hooks = getHooks(
-        hooksType.page,
-        manifest.wasm,
-        originStateHolder.current.hooks_key,
-      );
+    if (
+      details.type === "script" &&
+      (details.tabId < 0 || // is this a ServiceWorker or a SharedWorker?
+        details.url.endsWith("#__WEBCAT_hooked_worker__")) // ...or a dedicated Worker?
+    ) {
+      // Inject the WASM hooks
+      const hooks = getHooks(hooksType.page, manifest.wasm);
       filter.write(stringToUint8Array(hooks));
     }
 

--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -232,10 +232,10 @@ export async function validateResponseContent(
   let manifest: Manifest;
   const filter = browser.webRequest.filterResponseData(details.requestId);
   filter.onstart = () => {
-      originStateHolder = getVerifiedManifestState(fqdn);
-      manifest = (originStateHolder.current as OriginStateVerifiedManifest)
-        .manifest;
-  }
+    originStateHolder = getVerifiedManifestState(fqdn);
+    manifest = (originStateHolder.current as OriginStateVerifiedManifest)
+      .manifest;
+  };
 
   const source: ArrayBuffer[] = [];
   filter.ondata = (event: { data: ArrayBuffer }) => {


### PR DESCRIPTION
This PR removes the need to hook WASM from each JavaScript file individually. Instead it moves everything to the content script and installs hooks using `exportFunction`. Workers, SharedWorkers, and ServiceWorkers are still hooked by injecting directly to the script file. To detect dedicated Workers at the network level, the Worker constructor is also hooked.

This PR also fixes some bugs; most notably it adds the missing `compileOptions` parameter to all WASM methods that support it.

This is an alternative to PR #139 and only one of the two should be merged.