### PR TITLE
Return in case of error during file validation

### DIFF
--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -268,6 +268,7 @@ export async function validateResponseContent(
         fqdn,
         new WebcatError(WebcatErrorCode.File.MISSING),
       );
+      return;
     }
 
     const content_hash = await SHA256(blob);
@@ -289,6 +290,7 @@ export async function validateResponseContent(
           String(Uint8ArrayToBase64Url(new Uint8Array(content_hash))),
         ]),
       );
+      return;
     }
 
     // If everything is OK then we can just write the raw blob back


### PR DESCRIPTION
Fixes https://github.com/freedomofpress/webcat/issues/131

Occasionally, if the first deny() occurred, the code would continue to the second one, trying to use a stream that was already closed, likely causing the issue reported there.