### PR TITLE
CI for integration tests for firefox, firefox-esr and tbb

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -86,14 +86,6 @@ jobs:
           firefox --headless -CreateProfile "default" 2>/dev/null || true
           timeout 5 firefox --headless || true
 
-      - name: Build test extension
-        working-directory: extension
-        run: make package-test
-
-      - name: Install test dependencies
-        working-directory: test
-        run: make install
-
       - name: Run integration tests
         run: |
           make test TESTARGS="--addon ../dist/webcat-extension-test.zip \

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,6 +37,19 @@ jobs:
         with:
           node-version: '23'
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+
+      - name: Install sigsum
+        run: |
+          go install sigsum.org/sigsum-go/cmd/sigsum-key@latest
+          go install sigsum.org/sigsum-go/cmd/sigsum-submit@latest
+
+      - name: Install webcat CLI
+        run: npm install -g @freedomofpress/webcat-cli
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,6 +70,19 @@ jobs:
           tar -xf tbb.tar.xz
           echo "$PWD/tor-browser/Browser" >> "$GITHUB_PATH"
 
+      - name: Set up virtual display
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb
+          Xvfb :99 -screen 0 1024x768x24 &
+          echo "DISPLAY=:99" >> "$GITHUB_ENV"
+
+      - name: Initialize Firefox profile
+        if: ${{ !matrix.tor }}
+        run: |
+          firefox --headless -CreateProfile "default" 2>/dev/null || true
+          timeout 5 firefox --headless || true
+
       - name: Build test extension
         working-directory: extension
         run: make package-test

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  MOZ_LEGACY_HOME: 1
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -95,10 +95,7 @@ jobs:
         run: make install
 
       - name: Run integration tests
-        working-directory: test
         run: |
-          .venv/bin/pytest -v tests.py \
-            --addon ../dist/webcat-extension-test.zip \
-            --headless \
-            -k "${{ matrix.test-filter }}"
+          make test TESTARGS="--addon ../dist/webcat-extension-test.zip \
+          --headless -k '${{ matrix.test-filter }}'"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,75 @@
+name: Integration Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Firefox (latest)
+            firefox-version: latest
+            test-filter: firefox
+          - name: Firefox ESR
+            firefox-version: latest-esr
+            test-filter: firefox
+          - name: Tor Browser
+            test-filter: tor
+            tor: true
+
+    name: ${{ matrix.name }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '23'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Firefox ${{ matrix.firefox-version }}
+        if: ${{ !matrix.tor }}
+        uses: browser-actions/setup-firefox@v1
+        with:
+          firefox-version: ${{ matrix.firefox-version }}
+
+      - name: Install Tor Browser
+        if: matrix.tor
+        run: |
+          TBB_URL=$(curl -s https://aus1.torproject.org/torbrowser/update_3/release/download-linux-x86_64.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['binary'])")
+          echo "Installing Tor Browser from ${TBB_URL}"
+          curl -fsSL "${TBB_URL}" -o tbb.tar.xz
+          tar -xf tbb.tar.xz
+          echo "$PWD/tor-browser/Browser" >> "$GITHUB_PATH"
+
+      - name: Build test extension
+        working-directory: extension
+        run: make package-test
+
+      - name: Install test dependencies
+        working-directory: test
+        run: make install
+
+      - name: Run integration tests
+        working-directory: test
+        run: |
+          .venv/bin/pytest -v tests.py \
+            --addon ../dist/webcat-extension-test.zip \
+            --headless \
+            -k "${{ matrix.test-filter }}"
+


### PR DESCRIPTION
It would be nice to have the tests run automatically. Since the project is open source, we shouldn't have billing problems related to the long duration of the tests.

The tests are split per target, so that we can quickly see if there's failures what would be affected. As we add tests, we might want to try to parallelize to speed them up, though in my experiments that had some reliability issues.