### PR TITLE
feat: add support for browser.storage.local backend

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -22,6 +22,7 @@
     "webRequest",
     "webRequestBlocking",
     "webRequestFilterResponse.serviceWorkerScript",
+    "storage",
     "tabs",
     "<all_urls>"
   ],

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -23,6 +23,7 @@
     "webRequestBlocking",
     "webRequestFilterResponse.serviceWorkerScript",
     "storage",
+    "unlimitedStorage",
     "tabs",
     "<all_urls>"
   ],

--- a/extension/src/globals.ts
+++ b/extension/src/globals.ts
@@ -7,7 +7,7 @@ import { OriginStateHolder } from "./webcat/interfaces/originstate";
 export const origins = new LRUCache<string, OriginStateHolder>(lru_set_size);
 export const nonOrigins = new LRUSet<string>(lru_cache_size);
 export const tabs: Map<number, string> = new Map();
-export const db = new WebcatDatabase("webcat");
+export const db = new WebcatDatabase();
 export const hookMarker = stringToUint8Array(
   `__WEBCAT_HOOK__{${Uint8ArrayToBase64Url(crypto.getRandomValues(new Uint8Array(32)))}}\n`,
 );

--- a/extension/src/webcat/db.ts
+++ b/extension/src/webcat/db.ts
@@ -1,232 +1,42 @@
 import { nonOrigins, origins } from "../globals"; // caching maps
-import { logger } from "./logger";
 import { extractHostname, extractRawHash } from "./parsers";
 
-type StorageMode = "indexeddb" | "storage.local" | "memory";
+const META_KEY = "block_meta";
 
-export interface ListMetadata {
-  hash: string;
-  treeHead: number;
+export interface BlockMeta {
+  blockTime: number;
+  rootHash: string;
 }
-
-interface WebcatStorageBackend {
-  settingsSet(key: string, value: number | string | bigint): Promise<void>;
-  settingsGet<T>(key: string): Promise<T | null>;
-  replaceList(leaves: readonly (readonly [string, string])[]): Promise<number>;
-  getEnrollmentByFqdn(fqdn: string): Promise<Uint8Array>;
-}
-
-// Settings keys
-const KEY_LAST_CHECKED = "lastChecked";
-const KEY_LAST_UPDATED = "lastUpdated";
-const KEY_ROOT_HASH = "rootHash";
-const KEY_LAST_BLOCK_TIME = "lastBlockTime";
-const KEY_LIST_COUNT = "listCount";
 
 export class WebcatDatabase {
-  private backendPromise: Promise<WebcatStorageBackend>;
-  public readonly storageMode: StorageMode;
-
-  constructor(private readonly name = "webcat") {
-    const { backendPromise, storageMode } = this.createStorageBackend(
-      this.name,
-    );
-    this.backendPromise = backendPromise;
-    this.storageMode = storageMode;
-  }
-
-  private async getBackend(): Promise<WebcatStorageBackend> {
-    return this.backendPromise;
-  }
-
-  private createStorageBackend(name: string): {
-    backendPromise: Promise<WebcatStorageBackend>;
-    storageMode: StorageMode;
-  } {
-    const backendPromise = this.tryIndexedDB(name)
-      .then((backend) => {
-        console.log("[webcat] Using IndexedDB backend");
-        return { backend, mode: "indexeddb" as StorageMode };
-      })
-      .catch((e) => {
-        console.warn("[webcat] IndexedDB unusable:", e);
-        return this.tryBrowserStorage().then((backend) => {
-          console.log("[webcat] Using browser.storage.local backend");
-          return { backend, mode: "storage.local" as StorageMode };
-        });
-      })
-      .catch((e) => {
-        console.warn(
-          "[webcat] browser.storage.local unusable, falling back to in-memory backend:",
-          e,
-        );
-        return {
-          backend: new InMemoryStorageBackend() as WebcatStorageBackend,
-          mode: "memory" as StorageMode,
-        };
-      });
-
-    backendPromise.then(({ mode }) => {
-      (this as { storageMode: StorageMode }).storageMode = mode;
-    });
-
-    return {
-      backendPromise: backendPromise.then(({ backend }) => backend),
-      storageMode: "indexeddb", // optimistic default, updated above
-    };
-  }
-
-  /** Try to open IndexedDB and verify it is writable (not read-only). */
-  private async tryIndexedDB(name: string): Promise<WebcatStorageBackend> {
-    if (typeof indexedDB === "undefined") {
-      throw new Error("indexedDB is undefined");
-    }
-
-    const db = await this.openDatabase(name);
-
-    // Probe: attempt a real write+delete to detect read-only mode (Tor Browser)
-    await new Promise<void>((resolve, reject) => {
-      try {
-        const tx = db.transaction("settings", "readwrite");
-        const store = tx.objectStore("settings");
-        const req = store.put({ key: "__webcat_probe", value: 1 });
-        req.onsuccess = () => {
-          store.delete("__webcat_probe");
-          resolve();
-        };
-        req.onerror = () => reject(new Error("IndexedDB write probe failed"));
-        tx.onerror = () =>
-          reject(new Error("IndexedDB write probe transaction failed"));
-      } catch (e) {
-        reject(e);
-      }
-    });
-
-    return new IndexedDbStorageBackend(db);
-  }
-
-  /** Try to use browser.storage.local and verify it is writable. */
-  private async tryBrowserStorage(): Promise<WebcatStorageBackend> {
-    if (
-      typeof browser === "undefined" ||
-      !browser.storage ||
-      !browser.storage.local
-    ) {
-      throw new Error("browser.storage.local is unavailable");
-    }
-
-    // Probe: verify we can actually write
-    await browser.storage.local.set({ __webcat_probe: 1 });
-    await browser.storage.local.remove("__webcat_probe");
-
-    return new BrowserStorageBackend();
-  }
-
-  private async openDatabase(name: string): Promise<IDBDatabase> {
-    return new Promise((resolve, reject) => {
-      const request = indexedDB.open(name, 1);
-
-      request.onupgradeneeded = (event) => {
-        const db = (event.target as IDBOpenDBRequest).result;
-
-        try {
-          const settings = db.createObjectStore("settings", { keyPath: "key" });
-          settings.createIndex("settings", "key", { unique: true });
-
-          const list = db.createObjectStore("list", { keyPath: "fqdn" });
-          list.createIndex("fqdnIndex", "fqdn", { unique: true });
-
-          console.log("[webcat] Created new list database");
-        } catch (e) {
-          reject(new Error(`Error creating object store: ${e}`));
-        }
-      };
-
-      request.onsuccess = (event) => {
-        const db = (event.target as IDBOpenDBRequest).result;
-        console.log("[webcat] Database opened successfully");
-        resolve(db);
-      };
-
-      request.onerror = (event) => {
-        reject(
-          new Error(
-            `Error opening database: ${(event.target as IDBOpenDBRequest).error?.message}`,
-          ),
-        );
-      };
-    });
-  }
-
-  async setLastChecked(): Promise<void> {
-    const now = Date.now();
-    const backend = await this.getBackend();
-    await backend.settingsSet(KEY_LAST_CHECKED, now);
-  }
-
-  async getLastChecked(): Promise<number | null> {
-    const backend = await this.getBackend();
-    return backend.settingsGet<number>(KEY_LAST_CHECKED);
-  }
-
-  async setLastUpdated(): Promise<void> {
-    const now = Date.now();
-    const backend = await this.getBackend();
-    await backend.settingsSet(KEY_LAST_UPDATED, now);
-  }
-
-  async getLastUpdated(): Promise<number | null> {
-    const backend = await this.getBackend();
-    return backend.settingsGet<number>(KEY_LAST_UPDATED);
-  }
-
-  async setRootHash(hash: string): Promise<void> {
-    const backend = await this.getBackend();
-    await backend.settingsSet(KEY_ROOT_HASH, hash);
-  }
-
-  async getRootHash(): Promise<string | null> {
-    const backend = await this.getBackend();
-    return backend.settingsGet<string>(KEY_ROOT_HASH);
-  }
-
-  async setLastBlockTime(seconds: bigint): Promise<void> {
-    const backend = await this.getBackend();
-    await backend.settingsSet(KEY_LAST_BLOCK_TIME, seconds);
-  }
-
-  async getLastBlockTime(): Promise<number | null> {
-    const backend = await this.getBackend();
-    return backend.settingsGet<number>(KEY_LAST_BLOCK_TIME);
-  }
-
-  async setListCount(count: number): Promise<void> {
-    const backend = await this.getBackend();
-    await backend.settingsSet(KEY_LIST_COUNT, count);
-  }
-
-  async getListCount(): Promise<number> {
-    const backend = await this.getBackend();
-    return (await backend.settingsGet<number>(KEY_LIST_COUNT)) ?? 0;
-  }
-
   async updateList(
     leaves: readonly (readonly [string, string])[],
+    meta: BlockMeta,
   ): Promise<void> {
-    const backend = await this.getBackend();
-    const processed = await backend.replaceList(leaves);
+    await browser.storage.local.clear();
 
-    // Clear caches after list update to prevent stale data usage
+    const batch: Record<string, unknown> = {};
+    for (const [reverseKey, hexHash] of leaves) {
+      const hostname = extractHostname(reverseKey);
+      const rawHash = extractRawHash(hexHash);
+      batch[hostname] = Array.from(rawHash);
+    }
+    batch[META_KEY] = meta;
+
+    await browser.storage.local.set(batch);
+
     origins.clear();
     nonOrigins.clear();
 
-    await this.setListCount(processed);
-    console.log(`[webcat] Replaced list with ${processed} leaves`);
+    console.log(`[webcat] Replaced list with ${leaves.length} entries`);
+  }
+
+  async getBlockMeta(): Promise<BlockMeta | null> {
+    const result = await browser.storage.local.get(META_KEY);
+    return (result[META_KEY] as BlockMeta) ?? null;
   }
 
   async getFQDNEnrollment(fqdn: string): Promise<Uint8Array> {
-    const backend = await this.getBackend();
-
     // 1. Positive-cache hit
     const originState = origins.get(fqdn);
     if (originState) {
@@ -244,210 +54,32 @@ export class WebcatDatabase {
       return new Uint8Array();
     }
 
-    // 3. Storage backend lookup
-    return backend.getEnrollmentByFqdn(fqdn);
-  }
-}
-
-class IndexedDbStorageBackend implements WebcatStorageBackend {
-  constructor(private readonly db: IDBDatabase) {}
-
-  async settingsSet(
-    key: string,
-    value: number | string | bigint,
-  ): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const tx = this.db.transaction("settings", "readwrite");
-      const st = tx.objectStore("settings");
-      const req = st.put({ key, value });
-
-      req.onsuccess = () => resolve();
-      req.onerror = () => reject(new Error(`Failed to set ${key}`));
-    });
-  }
-
-  async settingsGet<T>(key: string): Promise<T | null> {
-    return new Promise((resolve, reject) => {
-      const tx = this.db.transaction("settings", "readonly");
-      const st = tx.objectStore("settings");
-      const req = st.get(key);
-
-      req.onsuccess = () => {
-        if (!req.result) return resolve(null);
-        resolve(req.result.value as T);
-      };
-
-      req.onerror = () => reject(new Error(`Failed to get ${key}`));
-    });
-  }
-
-  async replaceList(
-    leaves: readonly (readonly [string, string])[],
-  ): Promise<number> {
-    const tx = this.db.transaction("list", "readwrite");
-    const store = tx.objectStore("list");
-
-    await new Promise<void>((resolve, reject) => {
-      const clearReq = store.clear();
-      clearReq.onsuccess = () => resolve();
-      clearReq.onerror = () =>
-        reject(new Error("Failed to clear old list entries"));
-    });
-
-    const CHUNK_SIZE = 1000;
-    let processed = 0;
-    for (let i = 0; i < leaves.length; i += CHUNK_SIZE) {
-      const chunk = leaves.slice(i, i + CHUNK_SIZE);
-      for (const [reverseKey, hexHash] of chunk) {
-        const hostname = extractHostname(reverseKey);
-        const rawHash = extractRawHash(hexHash);
-        store.add({ fqdn: hostname, policyhash: rawHash });
-        processed++;
-      }
-    }
-
-    await new Promise<void>((resolve, reject) => {
-      tx.oncomplete = () => resolve();
-      tx.onerror = () => reject(new Error("Transaction failed"));
-    });
-
-    return processed;
-  }
-
-  async getEnrollmentByFqdn(fqdn: string): Promise<Uint8Array> {
-    return new Promise((resolve, reject) => {
-      const tx = this.db.transaction("list", "readonly");
-      const store = tx.objectStore("list");
-      const index = store.index("fqdnIndex");
-      const req = index.get(fqdn);
-
-      req.onsuccess = () => {
-        const result = req.result;
-        if (result && result.policyhash) {
-          resolve(new Uint8Array(result.policyhash));
-        } else {
-          nonOrigins.add(fqdn);
-          resolve(new Uint8Array());
-        }
-      };
-
-      req.onerror = () => {
-        logger.addLog(
-          "error",
-          `Error fetching local database for enrollment, fqdn = ${fqdn}`,
-          -1,
-          fqdn,
-        );
-        reject(new Uint8Array());
-      };
-    });
-  }
-}
-
-class BrowserStorageBackend implements WebcatStorageBackend {
-  private readonly prefix = "webcat_";
-
-  private key(k: string): string {
-    return `${this.prefix}${k}`;
-  }
-
-  async settingsSet(
-    key: string,
-    value: number | string | bigint,
-  ): Promise<void> {
-    // bigint is not JSON-serializable, convert to string with a marker
-    const stored =
-      typeof value === "bigint"
-        ? { __bigint: true, value: value.toString() }
-        : value;
-    await browser.storage.local.set({ [this.key(key)]: stored });
-  }
-
-  async settingsGet<T>(key: string): Promise<T | null> {
-    const result = await browser.storage.local.get(this.key(key));
-    const stored = result[this.key(key)];
-    if (stored === undefined) return null;
-    if (stored && typeof stored === "object" && stored.__bigint) {
-      return BigInt(stored.value) as T;
-    }
-    return stored as T;
-  }
-
-  async replaceList(
-    leaves: readonly (readonly [string, string])[],
-  ): Promise<number> {
-    // Remove old list entries
-    const all = await browser.storage.local.get(null);
-    const oldKeys = Object.keys(all).filter((k) =>
-      k.startsWith(`${this.prefix}list_`),
-    );
-    if (oldKeys.length > 0) {
-      await browser.storage.local.remove(oldKeys);
-    }
-
-    // Store new entries in chunks to avoid exceeding message size limits
-    const CHUNK_SIZE = 500;
-    let processed = 0;
-    for (let i = 0; i < leaves.length; i += CHUNK_SIZE) {
-      const chunk = leaves.slice(i, i + CHUNK_SIZE);
-      const batch: Record<string, number[]> = {};
-      for (const [reverseKey, hexHash] of chunk) {
-        const hostname = extractHostname(reverseKey);
-        const rawHash = extractRawHash(hexHash);
-        batch[`${this.prefix}list_${hostname}`] = Array.from(rawHash);
-        processed++;
-      }
-      await browser.storage.local.set(batch);
-    }
-
-    return processed;
-  }
-
-  async getEnrollmentByFqdn(fqdn: string): Promise<Uint8Array> {
-    const key = `${this.prefix}list_${fqdn}`;
-    const result = await browser.storage.local.get(key);
-    const stored = result[key];
+    // 3. Storage lookup
+    const result = await browser.storage.local.get(fqdn);
+    const stored = result[fqdn];
     if (stored) {
       return new Uint8Array(stored);
-    }
-    nonOrigins.add(fqdn);
-    return new Uint8Array();
-  }
-}
-
-class InMemoryStorageBackend implements WebcatStorageBackend {
-  private readonly settings = new Map<string, number | string | bigint>();
-  private readonly list = new Map<string, Uint8Array>();
-
-  async settingsSet(
-    key: string,
-    value: number | string | bigint,
-  ): Promise<void> {
-    this.settings.set(key, value);
-  }
-
-  async settingsGet<T>(key: string): Promise<T | null> {
-    const value = this.settings.get(key);
-    return (value as T | undefined) ?? null;
-  }
-
-  async replaceList(
-    leaves: readonly (readonly [string, string])[],
-  ): Promise<number> {
-    this.list.clear();
-    for (const [reverseKey, hexHash] of leaves) {
-      const hostname = extractHostname(reverseKey);
-      const rawHash = extractRawHash(hexHash);
-      this.list.set(hostname, new Uint8Array(rawHash));
-    }
-    return this.list.size;
-  }
-
-  async getEnrollmentByFqdn(fqdn: string): Promise<Uint8Array> {
-    const result = this.list.get(fqdn);
-    if (!result) {
+    } else {
+      nonOrigins.add(fqdn);
       return new Uint8Array();
     }
-    return new Uint8Array(result);
+  }
+
+  async setLastChecked(): Promise<void> {
+    await browser.storage.session.set({ lastChecked: Date.now() });
+  }
+
+  async getLastChecked(): Promise<number | null> {
+    const result = await browser.storage.session.get("lastChecked");
+    return result.lastChecked ?? null;
+  }
+
+  async setLastUpdated(): Promise<void> {
+    await browser.storage.session.set({ lastUpdated: Date.now() });
+  }
+
+  async getLastUpdated(): Promise<number | null> {
+    const result = await browser.storage.session.get("lastUpdated");
+    return result.lastUpdated ?? null;
   }
 }

--- a/extension/src/webcat/db.ts
+++ b/extension/src/webcat/db.ts
@@ -2,7 +2,7 @@ import { nonOrigins, origins } from "../globals"; // caching maps
 import { logger } from "./logger";
 import { extractHostname, extractRawHash } from "./parsers";
 
-type StorageMode = "indexeddb" | "memory";
+type StorageMode = "indexeddb" | "storage.local" | "memory";
 
 export interface ListMetadata {
   hash: string;
@@ -43,28 +43,83 @@ export class WebcatDatabase {
     backendPromise: Promise<WebcatStorageBackend>;
     storageMode: StorageMode;
   } {
-    if (typeof indexedDB === "undefined") {
-      console.warn("[webcat] IndexedDB unavailable, using in-memory backend");
-      return {
-        backendPromise: Promise.resolve(new InMemoryStorageBackend()),
-        storageMode: "memory",
-      };
-    }
-
-    const backendPromise = this.openDatabase(name)
-      .then((db) => new IndexedDbStorageBackend(db))
+    const backendPromise = this.tryIndexedDB(name)
+      .then((backend) => {
+        console.log("[webcat] Using IndexedDB backend");
+        return { backend, mode: "indexeddb" as StorageMode };
+      })
+      .catch((e) => {
+        console.warn("[webcat] IndexedDB unusable:", e);
+        return this.tryBrowserStorage().then((backend) => {
+          console.log("[webcat] Using browser.storage.local backend");
+          return { backend, mode: "storage.local" as StorageMode };
+        });
+      })
       .catch((e) => {
         console.warn(
-          "[webcat] Falling back to in-memory backend after IndexedDB failure",
+          "[webcat] browser.storage.local unusable, falling back to in-memory backend:",
           e,
         );
-        return new InMemoryStorageBackend();
+        return {
+          backend: new InMemoryStorageBackend() as WebcatStorageBackend,
+          mode: "memory" as StorageMode,
+        };
       });
 
+    backendPromise.then(({ mode }) => {
+      (this as { storageMode: StorageMode }).storageMode = mode;
+    });
+
     return {
-      backendPromise,
-      storageMode: "indexeddb",
+      backendPromise: backendPromise.then(({ backend }) => backend),
+      storageMode: "indexeddb", // optimistic default, updated above
     };
+  }
+
+  /** Try to open IndexedDB and verify it is writable (not read-only). */
+  private async tryIndexedDB(name: string): Promise<WebcatStorageBackend> {
+    if (typeof indexedDB === "undefined") {
+      throw new Error("indexedDB is undefined");
+    }
+
+    const db = await this.openDatabase(name);
+
+    // Probe: attempt a real write+delete to detect read-only mode (Tor Browser)
+    await new Promise<void>((resolve, reject) => {
+      try {
+        const tx = db.transaction("settings", "readwrite");
+        const store = tx.objectStore("settings");
+        const req = store.put({ key: "__webcat_probe", value: 1 });
+        req.onsuccess = () => {
+          store.delete("__webcat_probe");
+          resolve();
+        };
+        req.onerror = () => reject(new Error("IndexedDB write probe failed"));
+        tx.onerror = () =>
+          reject(new Error("IndexedDB write probe transaction failed"));
+      } catch (e) {
+        reject(e);
+      }
+    });
+
+    return new IndexedDbStorageBackend(db);
+  }
+
+  /** Try to use browser.storage.local and verify it is writable. */
+  private async tryBrowserStorage(): Promise<WebcatStorageBackend> {
+    if (
+      typeof browser === "undefined" ||
+      !browser.storage ||
+      !browser.storage.local
+    ) {
+      throw new Error("browser.storage.local is unavailable");
+    }
+
+    // Probe: verify we can actually write
+    await browser.storage.local.set({ __webcat_probe: 1 });
+    await browser.storage.local.remove("__webcat_probe");
+
+    return new BrowserStorageBackend();
   }
 
   private async openDatabase(name: string): Promise<IDBDatabase> {
@@ -286,6 +341,77 @@ class IndexedDbStorageBackend implements WebcatStorageBackend {
         reject(new Uint8Array());
       };
     });
+  }
+}
+
+class BrowserStorageBackend implements WebcatStorageBackend {
+  private readonly prefix = "webcat_";
+
+  private key(k: string): string {
+    return `${this.prefix}${k}`;
+  }
+
+  async settingsSet(
+    key: string,
+    value: number | string | bigint,
+  ): Promise<void> {
+    // bigint is not JSON-serializable, convert to string with a marker
+    const stored =
+      typeof value === "bigint"
+        ? { __bigint: true, value: value.toString() }
+        : value;
+    await browser.storage.local.set({ [this.key(key)]: stored });
+  }
+
+  async settingsGet<T>(key: string): Promise<T | null> {
+    const result = await browser.storage.local.get(this.key(key));
+    const stored = result[this.key(key)];
+    if (stored === undefined) return null;
+    if (stored && typeof stored === "object" && stored.__bigint) {
+      return BigInt(stored.value) as T;
+    }
+    return stored as T;
+  }
+
+  async replaceList(
+    leaves: readonly (readonly [string, string])[],
+  ): Promise<number> {
+    // Remove old list entries
+    const all = await browser.storage.local.get(null);
+    const oldKeys = Object.keys(all).filter((k) =>
+      k.startsWith(`${this.prefix}list_`),
+    );
+    if (oldKeys.length > 0) {
+      await browser.storage.local.remove(oldKeys);
+    }
+
+    // Store new entries in chunks to avoid exceeding message size limits
+    const CHUNK_SIZE = 500;
+    let processed = 0;
+    for (let i = 0; i < leaves.length; i += CHUNK_SIZE) {
+      const chunk = leaves.slice(i, i + CHUNK_SIZE);
+      const batch: Record<string, number[]> = {};
+      for (const [reverseKey, hexHash] of chunk) {
+        const hostname = extractHostname(reverseKey);
+        const rawHash = extractRawHash(hexHash);
+        batch[`${this.prefix}list_${hostname}`] = Array.from(rawHash);
+        processed++;
+      }
+      await browser.storage.local.set(batch);
+    }
+
+    return processed;
+  }
+
+  async getEnrollmentByFqdn(fqdn: string): Promise<Uint8Array> {
+    const key = `${this.prefix}list_${fqdn}`;
+    const result = await browser.storage.local.get(key);
+    const stored = result[key];
+    if (stored) {
+      return new Uint8Array(stored);
+    }
+    nonOrigins.add(fqdn);
+    return new Uint8Array();
   }
 }
 

--- a/extension/src/webcat/update.ts
+++ b/extension/src/webcat/update.ts
@@ -158,8 +158,8 @@ export async function update(
       throw new Error("Block verification did not return a time");
     }
 
-    const lastBlockTime = await db.getLastBlockTime();
-    if (lastBlockTime !== null && out.headerTime.seconds <= lastBlockTime) {
+    const meta = await db.getBlockMeta();
+    if (meta !== null && out.headerTime.seconds <= meta.blockTime) {
       console.log("[webcat] Block already applied, skipping");
       lastUpdateFailed = false;
       return;
@@ -179,9 +179,10 @@ export async function update(
       throw new Error("proof did not verify against app hash");
     }
 
-    await db.updateList(verifiedLeaves);
-    await db.setLastBlockTime(out.headerTime?.seconds);
-    await db.setRootHash(leaves.proof.canonical_root_hash);
+    await db.updateList(verifiedLeaves, {
+      blockTime: Number(out.headerTime.seconds),
+      rootHash: leaves.proof.canonical_root_hash,
+    });
     if (!bundled) {
       await db.setLastUpdated();
     }

--- a/extension/tests/webcat/db.test.ts
+++ b/extension/tests/webcat/db.test.ts
@@ -1,0 +1,113 @@
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock globals
+vi.mock("../../src/globals", () => ({
+  origins: new Map(),
+  nonOrigins: { has: () => false, add: () => {}, clear: () => {} },
+}));
+
+vi.mock("../../src/webcat/logger", () => ({
+  logger: { addLog: vi.fn() },
+}));
+
+import { WebcatDatabase } from "../../src/webcat/db";
+
+// ---------------------------------------------------------------------------
+// Helpers – build a fake leaf that extractHostname / extractRawHash accept.
+// extractHostname expects "canonical/.tld.domain" (reversed labels).
+// extractRawHash expects a hex string starting with 0a <len> <payload…>.
+// ---------------------------------------------------------------------------
+function fakeLeaf(fqdn: string, payload: number[]): [string, string] {
+  const labels = fqdn.split(".").reverse();
+  const reverseKey = `canonical/.${labels.join(".")}`;
+  const raw = [0x0a, payload.length, ...payload];
+  const hex = raw.map((b) => b.toString(16).padStart(2, "0")).join("");
+  return [reverseKey, hex];
+}
+
+// ---------------------------------------------------------------------------
+// Fake browser.storage.local + session backed by plain objects
+// ---------------------------------------------------------------------------
+function makeFakeStore() {
+  let storage: Record<string, any> = {};
+  return {
+    get: vi.fn(async (keyOrNull: string | null) => {
+      if (keyOrNull === null) return { ...storage };
+      if (typeof keyOrNull === "string") {
+        return keyOrNull in storage ? { [keyOrNull]: storage[keyOrNull] } : {};
+      }
+      const result: Record<string, any> = {};
+      for (const k of keyOrNull as unknown as string[]) {
+        if (k in storage) result[k] = storage[k];
+      }
+      return result;
+    }),
+    set: vi.fn(async (items: Record<string, any>) => {
+      Object.assign(storage, items);
+    }),
+    remove: vi.fn(async (keys: string | string[]) => {
+      const arr = Array.isArray(keys) ? keys : [keys];
+      for (const k of arr) delete storage[k];
+    }),
+    clear: vi.fn(async () => {
+      storage = {};
+    }),
+  };
+}
+
+function fakeBrowserStorage() {
+  globalThis.browser = {
+    storage: {
+      local: makeFakeStore(),
+      session: makeFakeStore(),
+    },
+  };
+}
+
+describe("WebcatDatabase", () => {
+  let db: InstanceType<typeof WebcatDatabase>;
+
+  beforeEach(() => {
+    fakeBrowserStorage();
+    db = new WebcatDatabase();
+  });
+
+  it("updateList stores and retrieves enrollment by fqdn", async () => {
+    const leaf = fakeLeaf("example.com", [0xca, 0xfe]);
+    await db.updateList([leaf], { blockTime: 100 });
+
+    const enrollment = await db.getFQDNEnrollment("example.com");
+    expect(enrollment).toBeInstanceOf(Uint8Array);
+    expect(Array.from(enrollment)).toEqual([0xca, 0xfe]);
+  });
+
+  it("updateList clears old entries before writing new ones", async () => {
+    await db.updateList([fakeLeaf("old.com", [1])], { blockTime: 100 });
+    await db.updateList([fakeLeaf("new.com", [2])], { blockTime: 200 });
+
+    const oldEnrollment = await db.getFQDNEnrollment("old.com");
+    expect(oldEnrollment.length).toBe(0);
+
+    const newEnrollment = await db.getFQDNEnrollment("new.com");
+    expect(Array.from(newEnrollment)).toEqual([2]);
+  });
+
+  it("stores and retrieves block meta", async () => {
+    await db.updateList([fakeLeaf("example.com", [1])], { blockTime: 42 });
+
+    const meta = await db.getBlockMeta();
+    expect(meta).toEqual({ blockTime: 42 });
+  });
+
+  it("getBlockMeta returns null when storage is empty", async () => {
+    const meta = await db.getBlockMeta();
+    expect(meta).toBeNull();
+  });
+
+  it("getFQDNEnrollment returns empty Uint8Array for unknown fqdn", async () => {
+    const result = await db.getFQDNEnrollment("nope.org");
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(0);
+  });
+});

--- a/extension/tests/webcat/response.test.ts
+++ b/extension/tests/webcat/response.test.ts
@@ -49,17 +49,15 @@ vi.mock("../../src/webcat/db", () => {
         return new Uint8Array();
       }),
 
-      getListCount: vi.fn(async () => 42),
-
       // Include other methods your test may call
       setLastChecked: vi.fn(),
       getLastChecked: vi.fn(async () => Date.now()),
 
       updateList: vi.fn(),
-      setRootHash: vi.fn(),
-      getRootHash: vi.fn(async () => "deadbeef"),
-      setLastBlockHeight: vi.fn(),
-      getLastBlockHeight: vi.fn(async () => 1337),
+      getBlockMeta: vi.fn(async () => ({
+        blockTime: 1337,
+        rootHash: "deadbeef",
+      })),
     })),
   };
 });

--- a/extension/tests/webcat/update.test.ts
+++ b/extension/tests/webcat/update.test.ts
@@ -65,9 +65,7 @@ function createMockDb() {
     setLastChecked: vi.fn(),
     setLastUpdated: vi.fn(),
     getLastUpdated: vi.fn(),
-    getLastBlockTime: vi.fn(),
-    setLastBlockTime: vi.fn(),
-    setRootHash: vi.fn(),
+    getBlockMeta: vi.fn(),
     updateList: vi.fn(),
   };
 }
@@ -155,7 +153,7 @@ describe("update", () => {
 
   beforeEach(() => {
     db = createMockDb();
-    db.getLastBlockTime.mockResolvedValue(null);
+    db.getBlockMeta.mockResolvedValue(null);
     setupFetchMock();
   });
 
@@ -210,19 +208,19 @@ describe("update", () => {
   it("updates the list and block time on success", async () => {
     await update(db as never, "https://example.com/");
 
-    expect(db.updateList).toHaveBeenCalledWith([["example.com", "abc123"]]);
-    expect(db.setLastBlockTime).toHaveBeenCalledWith(1000n);
-    expect(db.setRootHash).toHaveBeenCalledWith("aabbcc");
+    expect(db.updateList).toHaveBeenCalledWith([["example.com", "abc123"]], {
+      blockTime: 1000,
+      rootHash: "aabbcc",
+    });
   });
 
   it("skips update when block is already applied", async () => {
     // Block time from verifyCommit mock returns 1000n
-    db.getLastBlockTime.mockResolvedValue(1000n);
+    db.getBlockMeta.mockResolvedValue({ blockTime: 1000 });
 
     await update(db as never, "https://example.com/");
 
     expect(db.updateList).not.toHaveBeenCalled();
-    expect(db.setLastBlockTime).not.toHaveBeenCalled();
   });
 
   it("throws and sets failure flag on block verification failure", async () => {
@@ -265,7 +263,7 @@ describe("handleUpdateAlarm", () => {
   beforeEach(() => {
     db = createMockDb();
     setupFetchMock();
-    db.getLastBlockTime.mockResolvedValue(null);
+    db.getBlockMeta.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -320,7 +318,7 @@ describe("retryUpdateIfFailed", () => {
   beforeEach(() => {
     db = createMockDb();
     setupFetchMock();
-    db.getLastBlockTime.mockResolvedValue(null);
+    db.getBlockMeta.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -371,7 +369,7 @@ describe("initializeScheduledUpdates", () => {
   beforeEach(() => {
     db = createMockDb();
     setupFetchMock();
-    db.getLastBlockTime.mockResolvedValue(null);
+    db.getBlockMeta.mockResolvedValue(null);
     mockAlarms.get.mockResolvedValue(undefined);
     mockAlarms.create.mockReturnValue(undefined);
   });

--- a/extension/tests/webcat/validators.test.ts
+++ b/extension/tests/webcat/validators.test.ts
@@ -27,17 +27,15 @@ vi.mock("../../src/webcat/db", () => {
         return new Uint8Array();
       }),
 
-      getListCount: vi.fn(async () => 42),
-
       // Include other methods your test may call
       setLastChecked: vi.fn(),
       getLastChecked: vi.fn(async () => Date.now()),
 
       updateList: vi.fn(),
-      setRootHash: vi.fn(),
-      getRootHash: vi.fn(async () => "deadbeef"),
-      setLastBlockHeight: vi.fn(),
-      getLastBlockHeight: vi.fn(async () => 1337),
+      getBlockMeta: vi.fn(async () => ({
+        blockTime: 1337,
+        rootHash: "deadbeef",
+      })),
     })),
   };
 });


### PR DESCRIPTION
As suggested in https://github.com/freedomofpress/webcat/issues/98#issuecomment-4114271856 this PR adds support to `browser.storage.local` as a memory backend. The original class already supported testing IndexedDb and falling back on memory, while with this the order will be IndexedDb->storage.local->memory. It have tested in TBB and it seems to work.

Integration tests are passing. I think it's still useful to keep the memory fallback for now, but we might evaluate if to remove it in the future.