### PR TITLE
Fix NoScript compatibility

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,13 @@ jobs:
             firefox-version: latest-esr
             test-filter: firefox
           - name: Tor Browser
-            test-filter: tor
+            test-filter: tbb
+            tor: true
+          - name: Tor Browser (Safer)
+            test-filter: tbb_safer
+            tor: true
+          - name: Tor Browser (Safest)
+            test-filter: tbb_safest
             tor: true
 
     name: ${{ matrix.name }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
             firefox-version: latest-esr
             test-filter: firefox
           - name: Tor Browser
-            test-filter: tbb
+            test-filter: tbb and not tbb_safer and not tbb_safest
             tor: true
           - name: Tor Browser (Safer)
             test-filter: tbb_safer
@@ -79,10 +79,10 @@ jobs:
           tar -xf tbb.tar.xz
           echo "$PWD/tor-browser/Browser" >> "$GITHUB_PATH"
 
-      - name: Set up virtual display
+      - name: Set up virtual display and dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq xvfb
+          sudo apt-get install -y -qq xvfb libnss3-tools
           Xvfb :99 -screen 0 1024x768x24 &
           echo "DISPLAY=:99" >> "$GITHUB_ENV"
 

--- a/extension/src/globals.ts
+++ b/extension/src/globals.ts
@@ -11,3 +11,6 @@ export const db = new WebcatDatabase("webcat");
 export const hookMarker = stringToUint8Array(
   `__WEBCAT_HOOK__{${Uint8ArrayToBase64Url(crypto.getRandomValues(new Uint8Array(32)))}}\n`,
 );
+export const endMarker = stringToUint8Array(
+  `__WEBCAT_END__{${Uint8ArrayToBase64Url(crypto.getRandomValues(new Uint8Array(32)))}}\n`,
+);

--- a/extension/src/webcat/encoding.ts
+++ b/extension/src/webcat/encoding.ts
@@ -20,7 +20,7 @@ export function Uint8ArrayToBase64(uint8Array: Uint8Array): string {
   return btoa(binaryString);
 }
 
-export function stringToUint8Array(str: string): Uint8Array {
+export function stringToUint8Array(str: string): Uint8Array<ArrayBuffer> {
   // Defaults to utf-8, but utf-8 is ascii compatible
   const encoder = new TextEncoder();
   return encoder.encode(str);

--- a/extension/src/webcat/interfaces/originstate.ts
+++ b/extension/src/webcat/interfaces/originstate.ts
@@ -482,6 +482,10 @@ export class OriginStateVerifiedManifest extends OriginStateBase {
   }
 
   public verifyCSP(csp: string, pathname: string) {
+    // Consider only the first CSP. See
+    // https://github.com/freedomofpress/webcat/issues/160
+    csp = csp.split(",")[0];
+
     const extraCSP = this.manifest.extra_csp || {};
     const defaultCSP = this.manifest.default_csp;
 

--- a/extension/src/webcat/listeners.ts
+++ b/extension/src/webcat/listeners.ts
@@ -8,6 +8,7 @@ import { validateOrigin } from "./request";
 import { FRAME_TYPES } from "./resources";
 import {
   hookResponseContent,
+  markResponseContent,
   validateResponseContent,
   validateResponseHeaders,
 } from "./response";
@@ -122,6 +123,8 @@ export async function headersListener(
     errorpage(details.tabId, fqdn, result);
     return { cancel: true };
   }
+
+  markResponseContent(details);
 
   // Here we must have already validated the enrollment and the manifest
   // and thus should have all the information, but we haven't started

--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -1,4 +1,4 @@
-import { hookMarker, origins } from "./../globals";
+import { endMarker, hookMarker, origins } from "./../globals";
 import {
   base64UrlToUint8Array,
   stringToUint8Array,
@@ -242,10 +242,14 @@ export async function validateResponseContent(
     // The data here is usually chunked; normally it would be streamed down as we get it
     // but since we can hash the content only at the end, we have to wait until we have everything
     // before deciding if the response content matches the manifest or not. So we are saving it and we will
-    // build a blob later. If the data is the hook marker, we immediately inject the WASM hooks instead.
+    // build a blob later. If the data is the hook marker, replace it with the WASM hooks, and if it is the
+    // end marker, flush all buffered data
     if (arraysEqual(hookMarker, new Uint8Array(event.data))) {
       const hooks = getHooks(hooksType.page, manifest.wasm);
-      filter.write(stringToUint8Array(hooks));
+      source.push(stringToUint8Array(hooks).buffer);
+    } else if (arraysEqual(endMarker, new Uint8Array(event.data))) {
+      source.forEach((hook) => filter.write(hook));
+      source.length = 0;
     } else {
       source.push(event.data);
     }
@@ -315,14 +319,34 @@ export async function validateResponseContent(
   };
 }
 
-export async function hookResponseContent(
+export function hookResponseContent(
   details: browser.webRequest._OnBeforeSendHeadersDetails,
 ) {
-  const filter = browser.webRequest.filterResponseData(details.requestId);
-  filter.onstart = () => {
-    // insert hook marker, later replaced with
+  const hookMarkerInjector = browser.webRequest.filterResponseData(
+    details.requestId,
+  );
+  hookMarkerInjector.onstart = () => {
+    // Inject hook marker, later replaced with
     // the actual hook in the validation filter
-    filter.write(hookMarker);
-    filter.disconnect();
+    hookMarkerInjector.write(hookMarker);
+    hookMarkerInjector.disconnect();
+  };
+}
+
+export function markResponseContent(
+  details: browser.webRequest._OnHeadersReceivedDetails,
+) {
+  if (PASS_THROUGH_TYPES.has(details.type)) return;
+  // Install a marking filter at the last possible moment: after
+  // all extensions, including WEBCAT and NoScript, have injected their
+  // hooks, but before receiving any code from the network
+  const endMarkerInjector = browser.webRequest.filterResponseData(
+    details.requestId,
+  );
+  endMarkerInjector.onstart = () => {
+    // Inject the end marker, signaling the end of extension hooks and
+    // the start of code that should be validated
+    endMarkerInjector.write(endMarker);
+    endMarkerInjector.disconnect();
   };
 }

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -63,8 +63,12 @@ def server(root, headers, hooks):
 def browser(request):
     if request.param == "firefox":
         b = Browser()
-    elif request.param == "tor":
+    elif request.param == "tbb":
         b = TorBrowser(allowed_addons=["webcat@freedom.press"])
+    elif request.param == "tbb_safer":
+        b = TorBrowser(allowed_addons=["webcat@freedom.press"], security_level=TorBrowser.SecurityLevel.Safer)
+    elif request.param == "tbb_safest":
+        b = TorBrowser(allowed_addons=["webcat@freedom.press"], security_level=TorBrowser.SecurityLevel.Safest)
     else:
         raise RuntimeError(f'unrecognized browser \'{request.param}\'')
     b.start(request.config.getoption("--headless"))

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,10 +1,11 @@
 import os
+import tempfile
 import pytest
 import json
 import canonicaljson
 import hashlib
 
-from helpers import Browser, DB, Server, TorBrowser
+from helpers import Browser, DB, Server, TorBrowser, generate_ssl_cert
 from sigsum import generate_bundle
 from pytest_benchmark.fixture import BenchmarkFixture
 
@@ -33,6 +34,12 @@ def addon_path(request):
     return abs_path
 
 @pytest.fixture(scope="session")
+def ssl_cert():
+    tmpdir = tempfile.mkdtemp()
+    cert_path, key_path = generate_ssl_cert(tmpdir)
+    return cert_path, key_path
+
+@pytest.fixture(scope="session")
 def db():
     db = DB()
     db.start()
@@ -49,18 +56,22 @@ def root(db, request):
     return request.param
 
 @pytest.fixture(scope="function")
-def server(root, headers, hooks):
+def server(root, headers, hooks, ssl_cert):
+    cert_path, key_path = ssl_cert
     s = Server(
         root=root,
         headers=headers or {},
-        hooks=hooks or {}
+        hooks=hooks or {},
+        ssl_cert=cert_path,
+        ssl_key=key_path,
     )
     s.start()
     yield s
     s.stop()
 
 @pytest.fixture(scope="function")
-def browser(request):
+def browser(request, ssl_cert, server):
+    cert_path, _ = ssl_cert
     if request.param == "firefox":
         b = Browser()
     elif request.param == "tbb":
@@ -71,6 +82,7 @@ def browser(request):
         b = TorBrowser(allowed_addons=["webcat@freedom.press"], security_level=TorBrowser.SecurityLevel.Safest)
     else:
         raise RuntimeError(f'unrecognized browser \'{request.param}\'')
+    b.trust_cert(cert_path, server.port)
     b.start(request.config.getoption("--headless"))
     yield b
     b.destroy()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,6 +9,36 @@ from helpers import Browser, DB, Server, TorBrowser, generate_ssl_cert
 from sigsum import generate_bundle
 from pytest_benchmark.fixture import BenchmarkFixture
 
+_tbb_skips = {"corrupted_serviceworker_test": "ServiceWorkers not supported in Tor Browser"}
+_tbb_safer_skips = {
+    "basic_test": "WebAssembly not available at this security level",
+    "corrupted_wasm_test": "WebAssembly not available at this security level",
+    "corrupted_wasm_fetch_test": "WebAssembly not available at this security level",
+    "corrupted_wasm_worker_test": "WebAssembly not available at this security level",
+    "corrupted_wasm_audioworklet_test": "WebAssembly not available at this security level",
+}
+_tbb_safest_skips = {
+    "corrupted_js_test": "JavaScript fully disabled at this security level",
+    "corrupted_worker_test": "JavaScript fully disabled at this security level",
+    "corrupted_sharedworker_test": "JavaScript fully disabled at this security level",
+    "corrupted_audioworklet_test": "JavaScript fully disabled at this security level",
+}
+_browser_skips = {
+    "tbb": _tbb_skips,
+    "tbb_safer": {**_tbb_skips, **_tbb_safer_skips},
+    "tbb_safest": {**_tbb_skips, **_tbb_safer_skips, **_tbb_safest_skips},
+}
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        if not hasattr(item, "callspec"):
+            continue
+        browser_id = item.callspec.params.get("browser")
+        skips = _browser_skips.get(browser_id, {})
+        test_case = item.callspec.id.removesuffix(f"-{browser_id}")
+        if test_case in skips:
+            item.add_marker(pytest.mark.skip(reason=skips[test_case]))
+
 def pytest_addoption(parser):
     parser.addoption(
         "--addon", action="store", default=None,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,7 +7,6 @@ import hashlib
 from helpers import Browser, DB, Server, TorBrowser
 from sigsum import generate_bundle
 from pytest_benchmark.fixture import BenchmarkFixture
-from pytest_benchmark.utils import NameWrapper
 
 def pytest_addoption(parser):
     parser.addoption(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,6 +18,7 @@ _tbb_safer_skips = {
     "corrupted_wasm_audioworklet_test": "WebAssembly not available at this security level",
 }
 _tbb_safest_skips = {
+    "no_wasm_test": "JavaScript fully disabled at this security level",
     "corrupted_js_test": "JavaScript fully disabled at this security level",
     "corrupted_worker_test": "JavaScript fully disabled at this security level",
     "corrupted_sharedworker_test": "JavaScript fully disabled at this security level",

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -208,7 +208,8 @@ class TorBrowser(Browser):
         if override_profiles_path == "":
             override_profiles_path = TorBrowser.get_profiles_path()
         additional_configs["network.proxy.allow_hijacking_localhost"] = False
-        additional_configs.update(TorBrowser.SecurityLevel._get_config(security_level))
+        if security_level != TorBrowser.SecurityLevel.Standard:
+            additional_configs.update(TorBrowser.SecurityLevel._get_config(security_level))
         super().__init__(override_tbb_path, override_profiles_path, additional_configs)
         if len(allowed_addons) > 0:
             with open(self.profile_path.joinpath("extension-preferences.json"), "r") as file:

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -5,12 +5,22 @@ import queue
 import logging
 import subprocess
 import os
+import ssl
 import sys
+import tempfile
 import threading
 import http.server
 import socketserver
-from base64 import b64decode
+import hashlib
+import datetime
+import ipaddress
+from base64 import b64decode, b64encode
 from pathlib import Path
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 # --- Patch subprocess.Popen to discard Firefox output ---
 _original_popen = subprocess.Popen
@@ -74,6 +84,18 @@ class Browser:
             logging.info(f"Profile {self.profile_name} removed.")
         except:
             pass
+
+    def trust_cert(self, cert_path, port):
+        """Add a certificate override for 127.0.0.1:port via cert_override.txt."""
+        with open(cert_path, "rb") as f:
+            cert = x509.load_pem_x509_certificate(f.read())
+        der_data = cert.public_bytes(serialization.Encoding.DER)
+        sha256 = hashlib.sha256(der_data).hexdigest()
+        fingerprint = ":".join(sha256[i:i+2].upper() for i in range(0, len(sha256), 2))
+        db_key = b64encode(der_data).decode("ascii")
+        override_file = self.profile_path / "cert_override.txt"
+        with open(override_file, "a") as f:
+            f.write(f"127.0.0.1:{port}\tOID.2.16.840.1.101.3.4.2.1\t{fingerprint}\t{db_key}\n")
 
     def install_extension(self, path):
         root_actor_ids = self.root.get_root()
@@ -186,8 +208,7 @@ class TorBrowser(Browser):
         if override_profiles_path == "":
             override_profiles_path = TorBrowser.get_profiles_path()
         additional_configs["network.proxy.allow_hijacking_localhost"] = False
-        if security_level != TorBrowser.SecurityLevel.Standard:
-            additional_configs.update(TorBrowser.SecurityLevel._get_config(security_level))
+        additional_configs.update(TorBrowser.SecurityLevel._get_config(security_level))
         super().__init__(override_tbb_path, override_profiles_path, additional_configs)
         if len(allowed_addons) > 0:
             with open(self.profile_path.joinpath("extension-preferences.json"), "r") as file:
@@ -210,10 +231,12 @@ class Blob:
         self.type = type
 
 class Server:
-    def __init__(self, root=".", headers=None, hooks=None):
+    def __init__(self, root=".", headers=None, hooks=None, ssl_cert=None, ssl_key=None):
         self.root = os.path.abspath(root)
         self.headers = headers or {}
         self.hooks = hooks or {}
+        self.ssl_cert = ssl_cert
+        self.ssl_key = ssl_key
         self.port = None
 
     def start(self):
@@ -246,6 +269,10 @@ class Server:
             def log_message(self, *a): pass  # suppress logs
 
         self.httpd = socketserver.TCPServer(("127.0.0.1", 0), Handler)
+        if self.ssl_cert and self.ssl_key:
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.load_cert_chain(self.ssl_cert, self.ssl_key)
+            self.httpd.socket = context.wrap_socket(self.httpd.socket, server_side=True)
         self.port = self.httpd.server_address[1]
         self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
         self.thread.start()
@@ -254,7 +281,39 @@ class Server:
         self.httpd.shutdown()
         self.thread.join()
 
-    def url(self): return f"http://127.0.0.1:{self.port}"
+    def url(self):
+        scheme = "https" if self.ssl_cert else "http"
+        return f"{scheme}://127.0.0.1:{self.port}"
+
+def generate_ssl_cert(output_dir):
+    """Generate a self-signed certificate for 127.0.0.1."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "127.0.0.1")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.IPAddress(ipaddress.IPv4Address("127.0.0.1"))]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    cert_path = os.path.join(output_dir, "cert.pem")
+    key_path = os.path.join(output_dir, "key.pem")
+    with open(cert_path, "wb") as f:
+        f.write(cert.public_bytes(serialization.Encoding.PEM))
+    with open(key_path, "wb") as f:
+        f.write(key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        ))
+    return cert_path, key_path
 
 class DB:
     hosts = {}

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -131,8 +131,37 @@ class Browser:
             value = result_field
 
         return value
-    
-class TorBrowser(Browser):
+
+class TorBrowser(Browser): 
+    class SecurityLevel:
+        Standard = 4
+        Safer = 2
+        Safest = 1
+
+        @staticmethod
+        def _get_config(level):
+            if level < TorBrowser.SecurityLevel.Safest or level > TorBrowser.SecurityLevel.Standard:
+                raise RuntimeError(f"unrecognized security level '{level}'")
+            defaults = {
+                # https://gitlab.torproject.org/tpo/applications/tor-browser/-/blob/tor-browser-150.0a1-16.0-2/toolkit/components/securitylevel/SecurityLevel.sys.mjs?ref_type=heads#L253
+                "javascript.options.ion":                   [ None, False, False, False,  True ],
+                "javascript.options.baselinejit":           [ None, False, False, False,  True ],
+                "javascript.options.native_regexp":         [ None, False, False, False,  True ],
+                "mathml.disabled":                          [ None,  True,  True,  True, False ],
+                "gfx.font_rendering.graphite.enabled":      [ None, False, False, False,  True ],
+                "gfx.font_rendering.opentype_svg.enabled":  [ None, False, False, False,  True ],
+                "svg.disabled":                             [ None,  True, False, False, False ],
+                "javascript.options.asmjs":                 [ None, False, False, False, False ],
+                "javascript.options.wasm":                  [ None,  True,  True,  True,  True ],
+            }
+            config = {
+                "browser.security_level.security_slider": level,
+                "browser.security_level.noscript_inited": False,
+            }
+            for key, values in defaults.items():
+                config[key] = values[level]
+            return config
+
     @staticmethod
     def get_binary_path():
         if sys.platform == "darwin":
@@ -151,12 +180,14 @@ class TorBrowser(Browser):
             return Path.home() / "Library" / "Application Support" / "TorBrowser-Data" / "Browser"
         return Path(os.path.dirname(TorBrowser.get_binary_path())).joinpath("TorBrowser/Data/Browser/")
 
-    def __init__(self, override_tbb_path="", override_profiles_path="", additional_configs={}, allowed_addons=[]):
+    def __init__(self, override_tbb_path="", override_profiles_path="", additional_configs={}, allowed_addons=[], security_level=4):
         if override_tbb_path == "":
             override_tbb_path = TorBrowser.get_binary_path()
         if override_profiles_path == "":
             override_profiles_path = TorBrowser.get_profiles_path()
         additional_configs["network.proxy.allow_hijacking_localhost"] = False
+        if security_level != TorBrowser.SecurityLevel.Standard:
+            additional_configs.update(TorBrowser.SecurityLevel._get_config(security_level))
         super().__init__(override_tbb_path, override_profiles_path, additional_configs)
         if len(allowed_addons) > 0:
             with open(self.profile_path.joinpath("extension-preferences.json"), "r") as file:

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,4 +1,5 @@
 canonicaljson
+cryptography
 geckordp
 pytest
 pytest-benchmark

--- a/test/tests.py
+++ b/test/tests.py
@@ -65,6 +65,27 @@ def setdiff(a: list, b: list):
                                    "style-src 'self'; frame-src 'none'; worker-src 'self';"
     }, { }, "Hello!", EXPECTED_LOGS, [], []),
 
+    # Correct execution without WebAssembly or Workers
+    ("cases/testapp", {
+        "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
+                                   "style-src 'self'; frame-src 'none'; worker-src 'self';"
+    }, {
+        "/js/wasm.js": b"",
+        "/js/wasm_fetch.js": b"",
+        "/js/load_worker.js": b"",
+        "/js/load_sharedworker.js": b"",
+        "/js/load_wasmworker.js": b"",
+        "/js/load_audioworklet.js": b"",
+    }, "Hello!", setdiff(
+        EXPECTED_LOGS, [
+            LOGENTRY_WASM,
+            LOGENTRY_WASM_FETCH,
+            LOGENTRY_LOAD_WORKER,
+            LOGENTRY_LOAD_SHAREDWORKER,
+            LOGENTRY_LOAD_WASMWORKER,
+            LOGENTRY_LOAD_AUDIOWORKLET,
+        ]), [], []),
+
     # Wrong CSP
     ("cases/testapp", {
         "content-security-policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
@@ -152,6 +173,7 @@ def setdiff(a: list, b: list):
 
 ], ids=[
     "basic_test",
+    "no_wasm_test",
     "wrong_csp_test",
     "missing_csp_test",
     "corrupted_index_test",

--- a/test/tests.py
+++ b/test/tests.py
@@ -167,8 +167,33 @@ def setdiff(a: list, b: list):
     "corrupted_wasm_audioworklet_test",
 ], indirect=["root"])
 def test_webcat(browser, server, expected, logs, errors, rejections, addon_path, request):
-    if request.node.callspec.id == "corrupted_serviceworker_test-tbb":
-        pytest.skip("ServiceWorkers not supported in Tor Browser")
+    callspec_id = request.node.callspec.id
+    browser_id = request.node.callspec.params["browser"]
+    test_case = callspec_id.removesuffix(f"-{browser_id}")
+    tbb_skips = {"corrupted_serviceworker_test": "ServiceWorkers not supported in Tor Browser"}
+    tbb_safer_skips = {
+        "basic_test": "WebAssembly not available at this security level",
+        "corrupted_wasm_test": "WebAssembly not available at this security level",
+        "corrupted_wasm_fetch_test": "WebAssembly not available at this security level",
+        "corrupted_wasm_worker_test": "WebAssembly not available at this security level",
+        "corrupted_wasm_audioworklet_test": "WebAssembly not available at this security level",
+    }
+    tbb_safest_skips = {
+        "corrupted_js_test": "JavaScript fully disabled at this security level",
+        "corrupted_worker_test": "JavaScript fully disabled at this security level",
+        "corrupted_sharedworker_test": "JavaScript fully disabled at this security level",
+        "corrupted_audioworklet_test": "JavaScript fully disabled at this security level",
+    }
+    if browser_id == "tbb":
+        skips = tbb_skips
+    elif browser_id == "tbb_safer":
+        skips = {**tbb_skips, **tbb_safer_skips}
+    elif browser_id == "tbb_safest":
+        skips = {**tbb_skips, **tbb_safer_skips, **tbb_safest_skips}
+    else:
+        skips = {}
+    if test_case in skips:
+        pytest.skip(skips[test_case])
     
     browser.install_extension(addon_path)
     sleep(7)

--- a/test/tests.py
+++ b/test/tests.py
@@ -56,7 +56,7 @@ def setdiff(a: list, b: list):
             pass
     return a
 
-@pytest.mark.parametrize("browser", ["firefox", "tor"], indirect=True)
+@pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
 @pytest.mark.parametrize("root, headers, hooks, expected, logs, errors, rejections", [
 
     # Basic correct execution
@@ -167,7 +167,7 @@ def setdiff(a: list, b: list):
     "corrupted_wasm_audioworklet_test",
 ], indirect=["root"])
 def test_webcat(browser, server, expected, logs, errors, rejections, addon_path, request):
-    if request.node.callspec.id == "corrupted_serviceworker_test-tor":
+    if request.node.callspec.id == "corrupted_serviceworker_test-tbb":
         pytest.skip("ServiceWorkers not supported in Tor Browser")
     
     browser.install_extension(addon_path)
@@ -186,7 +186,7 @@ def test_webcat(browser, server, expected, logs, errors, rejections, addon_path,
     for err in res: assert err in rejections
     for err in rejections: assert err in res
 
-@pytest.mark.parametrize("browser", ["firefox", "tor"], indirect=True)
+@pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
 @pytest.mark.parametrize("root, headers, hooks, expected", [
     ("cases/testapp", {
         "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "

--- a/test/tests.py
+++ b/test/tests.py
@@ -166,35 +166,7 @@ def setdiff(a: list, b: list):
     "corrupted_audioworklet_test",
     "corrupted_wasm_audioworklet_test",
 ], indirect=["root"])
-def test_webcat(browser, server, expected, logs, errors, rejections, addon_path, request):
-    callspec_id = request.node.callspec.id
-    browser_id = request.node.callspec.params["browser"]
-    test_case = callspec_id.removesuffix(f"-{browser_id}")
-    tbb_skips = {"corrupted_serviceworker_test": "ServiceWorkers not supported in Tor Browser"}
-    tbb_safer_skips = {
-        "basic_test": "WebAssembly not available at this security level",
-        "corrupted_wasm_test": "WebAssembly not available at this security level",
-        "corrupted_wasm_fetch_test": "WebAssembly not available at this security level",
-        "corrupted_wasm_worker_test": "WebAssembly not available at this security level",
-        "corrupted_wasm_audioworklet_test": "WebAssembly not available at this security level",
-    }
-    tbb_safest_skips = {
-        "corrupted_js_test": "JavaScript fully disabled at this security level",
-        "corrupted_worker_test": "JavaScript fully disabled at this security level",
-        "corrupted_sharedworker_test": "JavaScript fully disabled at this security level",
-        "corrupted_audioworklet_test": "JavaScript fully disabled at this security level",
-    }
-    if browser_id == "tbb":
-        skips = tbb_skips
-    elif browser_id == "tbb_safer":
-        skips = {**tbb_skips, **tbb_safer_skips}
-    elif browser_id == "tbb_safest":
-        skips = {**tbb_skips, **tbb_safer_skips, **tbb_safest_skips}
-    else:
-        skips = {}
-    if test_case in skips:
-        pytest.skip(skips[test_case])
-    
+def test_webcat(browser, server, expected, logs, errors, rejections, addon_path):
     browser.install_extension(addon_path)
     sleep(7)
     browser.navigate(server.url())

--- a/test/tests.py
+++ b/test/tests.py
@@ -23,7 +23,7 @@ WEBCAT_ICON = Blob(
 
 BAD_WASM = Blob(
     "AGFzbQEAAAABCgJgAABgAn9/AX8DAwIAAQQFAXABAQEFBgEBggKCAgcRBAFhAgABYgAAAWMAAQFk"
-    "AQAKCQICAAsEAEEACw==", type="applicaiton/wasm", base64=True)
+    "AQAKCQICAAsEAEEACw==", type="application/wasm", base64=True)
 
 [
     LOGENTRY_ALERT,


### PR DESCRIPTION
The NoScript extension causes integrity errors in WEBCAT for two reasons: it adds custom CSP headers and patches worker scripts, making them no longer match the manifest. 

This PR deals with the first issue by ignoring all CSPs other than the first one. It is safe to do, because additional CSPs can only restrict the page further, not relax any previous rules. NoScript always only appends new CSPs, never modifies the original.

The second issue is slightly more complicated. This PR adds a new response filter that injects a marker tag. The response filter is installed in the onHeadersReceived listener, making it the last filter to be added; both WEBCAT and NoScript install other filters in the onBeforeRequest and onBeforeSendHeaders listeners. This order is important: the new filter runs last, meaning the injected tag is the last thing injected before receiving content from the network. The existing validation filter can then use the injected tag to detect which parts of the content are coming from extensions (everything before the tag) and which from the network (everything after the tag), ignore injected content, and compute the correct hash for the original content.

Fixes #160.