### PR TITLE
Add a test for a bypass attack with multiple tabs

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -23,6 +23,7 @@ _tbb_safest_skips = {
     "corrupted_worker_test": "JavaScript fully disabled at this security level",
     "corrupted_sharedworker_test": "JavaScript fully disabled at this security level",
     "corrupted_audioworklet_test": "JavaScript fully disabled at this security level",
+    "corrupted_js_with_induced_error_test": "JavaScript fully disabled at this security level",
 }
 _browser_skips = {
     "tbb": _tbb_skips,

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -7,7 +7,6 @@ import subprocess
 import os
 import ssl
 import sys
-import tempfile
 import threading
 import http.server
 import socketserver
@@ -16,6 +15,7 @@ import datetime
 import ipaddress
 from base64 import b64decode, b64encode
 from pathlib import Path
+from time import sleep
 
 from cryptography import x509
 from cryptography.x509.oid import NameOID
@@ -54,6 +54,7 @@ class Browser:
         profile.set_required_configs()
         profile.set_config("browser.shell.checkDefaultBrowser", False)
         profile.set_config("browser.startup.couldRestoreSession.count", -1)
+        profile.set_config("dom.disable_open_during_load", False)
         for key, value in additional_configs.items():
             profile.set_config(key, value)
         logging.info(f"Profile {self.profile_name} created.")
@@ -223,8 +224,9 @@ class TorBrowser(Browser):
             with open(self.profile_path.joinpath("extension-preferences.json"), "w") as file:
                 json.dump(prefs, file)
 
-class Blob:
-    def __init__(self, data, type="text/plain", base64=False):
+class Hook:
+    def __init__(self, data, type="text/plain", base64=False, delay=0, headers={}):
+        self.delay, self.headers = delay, headers
         if base64:
             self.data = b64decode(data)
         else:
@@ -257,14 +259,17 @@ class Server:
                         self.wfile.write(hook)
                     else:
                         self.send_header("Content-Type", hook.type)
-                        self.end_headers()
+                        self.end_headers(hook.headers)
                         self.wfile.write(hook.data)
+                        sleep(hook.delay)
 
                 else:
                     super().do_GET()
 
-            def end_headers(self):
-                for k, v in headers.items(): self.send_header(k, v)
+            def end_headers(self, override={}):
+                h = headers.copy()
+                h.update(override)
+                for k, v in h.items(): self.send_header(k, v)
                 super().end_headers()
 
             def log_message(self, *a): pass  # suppress logs

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,6 +1,6 @@
 import pytest
 from time import sleep
-from helpers import Browser, TorBrowser, Server, Blob
+from helpers import Browser, Server, Hook
 import logging
 import json
 
@@ -8,7 +8,7 @@ logging.getLogger("geckordp").setLevel(logging.CRITICAL)
 logging.getLogger("psutil").setLevel(logging.CRITICAL)
 logging.getLogger().setLevel(logging.WARNING)
 
-WEBCAT_ICON = Blob(
+WEBCAT_ICON = Hook(
     "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAABGdBTUEAALGPC/xhBQAAACBjSFJN"
     "AAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAAmJLR0QA/4ePzL8AAAAHdElN"
     "RQfoChYSHzod9YOfAAABNUlEQVQoz1XRv0ubARDG8c+bvMFW/BFfaAMupZWKgoPULQWXgg3orFBE"
@@ -21,7 +21,7 @@ WEBCAT_ICON = Blob(
     "ZnkAMjAyNC0xMC0yMlQxNDo1Mzo0MyswMDowMGXvS2oAAAAASUVORK5CYII=",
     type="image/png", base64=True)
 
-BAD_WASM = Blob(
+BAD_WASM = Hook(
     "AGFzbQEAAAABCgJgAABgAn9/AX8DAwIAAQQFAXABAQEFBgEBggKCAgcRBAFhAgABYgAAAWMAAQFk"
     "AQAKCQICAAsEAEEACw==", type="application/wasm", base64=True)
 
@@ -143,25 +143,25 @@ def setdiff(a: list, b: list):
     ("cases/testapp", {
         "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
                                    "style-src 'self'; frame-src 'none'; worker-src 'self';"
-    }, {"/workers/worker.js": Blob(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], []),
+    }, {"/workers/worker.js": Hook(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], []),
 
     # Hook /workers/sharedworker.js
     ("cases/testapp", {
         "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
                                    "style-src 'self'; frame-src 'none'; worker-src 'self';"
-    }, {"/workers/sharedworker.js": Blob(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], []),
+    }, {"/workers/sharedworker.js": Hook(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], []),
 
     # Hook /workers/serviceworker.js
     ("cases/testapp", {
         "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
                                    "style-src 'self'; frame-src 'none'; worker-src 'self';"
-    }, {"/workers/serviceworker.js": Blob(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], []),
+    }, {"/workers/serviceworker.js": Hook(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], []),
 
     # Hook /workers/audioworklet.js
     ("cases/testapp", {
         "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
                                    "style-src 'self'; frame-src 'none'; worker-src 'self';"
-    }, {"/workers/audioworklet.js": Blob(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], []),
+    }, {"/workers/audioworklet.js": Hook(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], []),
     
     # Hook /wasm/aw_addTwo.wasm
     ("cases/testapp", {
@@ -220,5 +220,29 @@ def test_in_memory_cache(browser, server, expected, addon_path):
     sleep(7)
     browser.navigate(f'{server.url()}/console_log.png')
     sleep(2)
+    res = browser.execute("document.body.innerText")
+    assert expected in res
+
+@pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
+@pytest.mark.parametrize("root, headers, hooks, expected", [
+    ("cases/testapp", {
+        "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
+                                   "style-src 'self'; frame-src 'none'; worker-src 'self';",
+    }, {
+        "/": Hook(open("cases/testapp/index.html", "rb").read(), type="text/html", delay=2),
+        "/js/alert.js": Hook(b"alert('hacked');", type="text/javascript"),
+        "/x": Hook(b"", type="text/html", headers={"refresh": "0"}),
+    }, "ERR_WEBCAT_FILE_MISMATCH"),
+], indirect=["root"], ids=[
+    "corrupted_js_with_induced_error_test",
+])
+def test_multiple_tabs(browser: Browser, server: Server, expected, addon_path):
+    browser.install_extension(addon_path)
+    sleep(7)
+    browser.execute(
+        f"window.open('{server.url()}');"
+        f"setTimeout(() => location.href = '{server.url()}/x', 1000)"
+    )
+    sleep(3)
     res = browser.execute("document.body.innerText")
     assert expected in res


### PR DESCRIPTION
Add a test for an attack that allows bypassing integrity checks: inducing an error in one tab while another tab is still loading causes the `webRequest` listeners for that origin to be unregistered, allowing responses to pass through unvalidated. The test FAILS on Firefox because there is an attack, but PASSES on TBB because TBB seems to enforce a strange ordering of the requests. The pass on TBB doesn't mean the issue couldn't be exploited on TBB under any circumstances.