### PR TITLE
Always intercept enrolled domains

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,13 +1,11 @@
 import { endpoint } from "./config";
 import { db } from "./globals";
 import {
-  headersListener,
+  installEnrolledListeners,
   installListener,
-  requestListener,
   startupListener,
   tabCloseListener,
 } from "./webcat/listeners";
-import { FRAME_TYPES } from "./webcat/resources";
 import { setErrorIcon } from "./webcat/ui";
 import {
   handleUpdateAlarm,
@@ -17,13 +15,18 @@ import {
 
 console.log("[webcat] Starting up background");
 
-// Import bundled list and initialize scheduled updates
 (async () => {
   try {
     console.log("[webcat] Importing bundled list");
     await update(db, endpoint, true);
   } catch (error) {
     console.error("[webcat] Bundled list import failed:", error);
+  }
+
+  try {
+    await installEnrolledListeners(db);
+  } catch (error) {
+    console.error("[webcat] Initial listener install failed:", error);
   }
 
   console.log("[webcat] Attempting network update");
@@ -47,40 +50,6 @@ browser.runtime.onInstalled.addListener(installListener);
 
 // On every startup download the diff(s)
 browser.runtime.onStartup.addListener(startupListener);
-
-// This is our request listener to start catching everything
-browser.webRequest.onBeforeRequest.addListener(
-  requestListener,
-  // We intercept http too because if a website is enrolled but not TLS enabled we want to drop
-  // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType
-  {
-    // New strategy: we detect here if a website is enrolled and then add a per-origin
-    // listener that intercwpts everything. This way we can always try to match a resource
-    // to the manifest first, including images, etc
-    urls: ["http://*/*", "https://*/*"],
-    types: FRAME_TYPES,
-  },
-  // Allowed remaining are beacon, csp_report, font, image, imageset, media, object_subrequest, ping, speculative, websocket, xmlhttprequest
-  ["blocking"],
-);
-
-// See https://github.com/freedomofpress/webcat/issues/137
-browser.webRequest.handlerBehaviorChanged();
-
-// To check if the headers were modified by another extension and abort, we could use
-// https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onResponseStarted
-browser.webRequest.onHeadersReceived.addListener(
-  headersListener,
-  // Here HTTP should no longer be a concern, we should have dropped the request before receiving headers anyway
-  // However that would not be the case for .onion domains
-  {
-    // Same as above, add more precise listener when something enrolled is detected
-    urls: ["http://*/*", "https://*/*"],
-    types: FRAME_TYPES,
-  },
-  // Do we want this to be "blocking"? If we detect an anomaly we should stop
-  ["blocking", "responseHeaders"],
-);
 
 // Not the best performance idea to act on all tab just for this
 browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {

--- a/extension/src/mocks/db.mock.ts
+++ b/extension/src/mocks/db.mock.ts
@@ -34,6 +34,15 @@ export class WebcatDatabase extends OriginalWebcatDatabase {
     console.log(`[TESTING] No enrollment found for ${fqdn}`);
     return new Uint8Array();
   }
+
+  async listAllFQDNs(): Promise<string[]> {
+    if (!listLoaded) {
+      await load();
+    }
+    const fqdns = Object.keys(list);
+    console.log(`[TESTING] listAllFQDNs returning ${fqdns.length} entries`);
+    return fqdns;
+  }
 }
 
 console.log("[TESTING] Mock db module loaded");

--- a/extension/src/webcat/cache.ts
+++ b/extension/src/webcat/cache.ts
@@ -1,18 +1,10 @@
-type Destructible = { destructor?: () => void };
-
-export class LRUCache<K, V extends Destructible> {
+export class LRUCache<K, V> {
   private cache: Map<K, V>;
   private limit: number;
 
   constructor(limit: number) {
     this.limit = limit;
     this.cache = new Map<K, V>();
-  }
-
-  private callDestructor(value: V): void {
-    if (value.destructor) {
-      value.destructor();
-    }
   }
 
   get(key: K): V | undefined {
@@ -47,17 +39,10 @@ export class LRUCache<K, V extends Destructible> {
   }
 
   delete(key: K): void {
-    const value = this.cache.get(key);
-    if (value !== undefined) {
-      this.callDestructor(value);
-    }
     this.cache.delete(key);
   }
 
   clear(): void {
-    for (const value of this.cache.values()) {
-      this.callDestructor(value);
-    }
     this.cache.clear();
   }
 }

--- a/extension/src/webcat/db.ts
+++ b/extension/src/webcat/db.ts
@@ -36,6 +36,11 @@ export class WebcatDatabase {
     return (result[META_KEY] as BlockMeta) ?? null;
   }
 
+  async listAllFQDNs(): Promise<string[]> {
+    const all = await browser.storage.local.get(null);
+    return Object.keys(all).filter((k) => k !== META_KEY);
+  }
+
   async getFQDNEnrollment(fqdn: string): Promise<Uint8Array> {
     // 1. Positive-cache hit
     const originState = origins.get(fqdn);

--- a/extension/src/webcat/interfaces/originstate.ts
+++ b/extension/src/webcat/interfaces/originstate.ts
@@ -2,11 +2,6 @@ import { bundle_name, bundle_prev_name } from "../../config";
 import { db } from "../../globals";
 import { canonicalize } from "../canonicalize";
 import { stringToUint8Array } from "../encoding";
-import {
-  beforeHeadersListener,
-  headersListener,
-  requestListener,
-} from "../listeners";
 import { arraysEqual } from "../utils";
 import { SHA256 } from "../utils";
 import { validateCSP, validateSigstoreEnrollment } from "../validators";
@@ -110,21 +105,7 @@ export class OriginStateHolder {
       | OriginStateVerifiedEnrollment
       | OriginStateVerifiedManifest
       | OriginStateFailed,
-  ) {
-    // Empty for now
-  }
-
-  destructor(): void {
-    browser.webRequest.onBeforeRequest.removeListener(
-      this.current.onBeforeRequest,
-    );
-    browser.webRequest.onBeforeSendHeaders.removeListener(
-      this.current.onBeforeSendHeaders,
-    );
-    browser.webRequest.onHeadersReceived.removeListener(
-      this.current.onHeadersReceived,
-    );
-  }
+  ) {}
 }
 
 // The OriginState class caches origins and assumes safe defaults. We assume we are enrolled and nothing is verified.
@@ -148,19 +129,6 @@ export abstract class OriginStateBase {
   public readonly valid_sources?: Set<string>;
   public readonly delegation?: string;
 
-  // Per origin function wrappers: the extension API does not support registering
-  // the same listener multiple times with different rules. We thus want a wrapper
-  // listener per every origin for their own intercepting function
-  public onBeforeRequest: (
-    details: browser.webRequest._OnBeforeRequestDetails,
-  ) => Promise<browser.webRequest.BlockingResponse>;
-  public onBeforeSendHeaders: (
-    details: browser.webRequest._OnBeforeSendHeadersDetails,
-  ) => Promise<browser.webRequest.BlockingResponse>;
-  public onHeadersReceived: (
-    details: browser.webRequest._OnHeadersReceivedDetails,
-  ) => Promise<browser.webRequest.BlockingResponse>;
-
   // Due to list logic, we support only one app per domain, and that should be a privileged one
   // But that is enforced in request.ts
   constructor(
@@ -176,10 +144,6 @@ export abstract class OriginStateBase {
     this.fqdn = fqdn;
     this.enrollment_hash = enrollment_hash;
     this.references = 1;
-
-    this.onBeforeRequest = (details) => requestListener(details);
-    this.onBeforeSendHeaders = (details) => beforeHeadersListener(details);
-    this.onHeadersReceived = (details) => headersListener(details);
 
     // Cleanup service workers, see https://github.com/freedomofpress/webcat/issues/18
     // and upcoming MPI/CISPA paper
@@ -346,9 +310,6 @@ export class OriginStateVerifiedEnrollment extends OriginStateBase {
       prev.fqdn,
       prev.enrollment_hash,
     );
-    this.onBeforeRequest = prev.onBeforeRequest;
-    this.onBeforeSendHeaders = prev.onBeforeSendHeaders;
-    this.onHeadersReceived = prev.onHeadersReceived;
     this.references = prev.references;
     this.enrollment = enrollment;
     this.delegation = delegation;
@@ -470,9 +431,6 @@ export class OriginStateVerifiedManifest extends OriginStateBase {
       prev.fqdn,
       prev.enrollment_hash,
     );
-    this.onBeforeRequest = prev.onBeforeRequest;
-    this.onBeforeSendHeaders = prev.onBeforeSendHeaders;
-    this.onHeadersReceived = prev.onHeadersReceived;
     this.references = prev.references;
     this.enrollment = prev.enrollment;
     this.manifest = manifest;

--- a/extension/src/webcat/listeners.ts
+++ b/extension/src/webcat/listeners.ts
@@ -1,5 +1,6 @@
 import { endpoint } from "../config";
 import { db, origins, tabs } from "../globals";
+import type { WebcatDatabase } from "./db";
 import { getHooks } from "./genhooks";
 import { hooksType, metadataRequestSource } from "./interfaces/base";
 import { WebcatError } from "./interfaces/errors";
@@ -265,4 +266,107 @@ export async function requestListener(
   // See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/BlockingResponse
   // Returning a response here is a very powerful tool, let's think about it later
   return {};
+}
+
+// Single global webRequest listener registration that scopes to the union
+// of currently enrolled FQDNs. We re-register the listeners on every list
+// update; we always add the new listener before removing the old one, so
+// there is no window with no listener.
+type RegisteredListeners = {
+  before?: (
+    details: browser.webRequest._OnBeforeRequestDetails,
+  ) => Promise<browser.webRequest.BlockingResponse>;
+  beforeHeaders?: (
+    details: browser.webRequest._OnBeforeSendHeadersDetails,
+  ) => Promise<browser.webRequest.BlockingResponse>;
+  headers?: (
+    details: browser.webRequest._OnHeadersReceivedDetails,
+  ) => Promise<browser.webRequest.BlockingResponse>;
+};
+
+let currentListeners: RegisteredListeners = {};
+
+function buildUrlPatterns(fqdns: string[]): string[] {
+  const urls: string[] = [];
+  for (const fqdn of fqdns) {
+    urls.push(`http://${fqdn}/*`);
+    urls.push(`https://${fqdn}/*`);
+  }
+  return urls;
+}
+
+function removeListeners(listeners: RegisteredListeners): void {
+  if (listeners.before) {
+    browser.webRequest.onBeforeRequest.removeListener(listeners.before);
+  }
+  if (listeners.beforeHeaders) {
+    browser.webRequest.onBeforeSendHeaders.removeListener(
+      listeners.beforeHeaders,
+    );
+  }
+  if (listeners.headers) {
+    browser.webRequest.onHeadersReceived.removeListener(listeners.headers);
+  }
+}
+
+export async function installEnrolledListeners(
+  database: WebcatDatabase,
+): Promise<void> {
+  let fqdns: string[];
+  try {
+    fqdns = await database.listAllFQDNs();
+  } catch (error) {
+    console.error("[webcat] listAllFQDNs failed:", error);
+    return;
+  }
+
+  if (fqdns.length === 0) {
+    if (
+      currentListeners.before ||
+      currentListeners.beforeHeaders ||
+      currentListeners.headers
+    ) {
+      removeListeners(currentListeners);
+      currentListeners = {};
+      browser.webRequest.handlerBehaviorChanged();
+    }
+    console.log("[webcat] installEnrolledListeners: 0 enrolled FQDNs");
+    return;
+  }
+
+  const urls = buildUrlPatterns(fqdns);
+
+  // The registration needs to be different from the existing one
+  const before = (details: browser.webRequest._OnBeforeRequestDetails) =>
+    requestListener(details);
+  const beforeHeaders = (
+    details: browser.webRequest._OnBeforeSendHeadersDetails,
+  ) => beforeHeadersListener(details);
+  const headers = (details: browser.webRequest._OnHeadersReceivedDetails) =>
+    headersListener(details);
+
+  // Add new listeners first, then remove the old ones
+  browser.webRequest.onBeforeRequest.addListener(before, { urls }, [
+    "blocking",
+  ]);
+  browser.webRequest.onBeforeSendHeaders.addListener(
+    beforeHeaders,
+    { urls, types: ["script"] },
+    ["blocking", "requestHeaders"],
+  );
+  browser.webRequest.onHeadersReceived.addListener(headers, { urls }, [
+    "blocking",
+    "responseHeaders",
+  ]);
+
+  const previous = currentListeners;
+  currentListeners = { before, beforeHeaders, headers };
+  removeListeners(previous);
+
+  // See https://github.com/freedomofpress/webcat/issues/137
+  browser.webRequest.handlerBehaviorChanged();
+
+  console.log(
+    `[webcat] installEnrolledListeners: registered listeners for ${fqdns.length} FQDN(s)`,
+  );
 }

--- a/extension/src/webcat/request.ts
+++ b/extension/src/webcat/request.ts
@@ -8,7 +8,6 @@ import {
   OriginStateInitial,
 } from "./interfaces/originstate";
 import { logger } from "./logger";
-import { NON_FRAME_TYPES } from "./resources";
 import { setIcon } from "./ui";
 import { enforceHTTPS, validateProtocolAndPort } from "./validators";
 
@@ -79,34 +78,6 @@ export async function validateOrigin(
 
   // See https://github.com/freedomofpress/webcat/issues/95
   await origin.current.fetcher.awaitAll();
-
-  // We want to intercept everything for enrolled wbesites
-  browser.webRequest.onBeforeRequest.addListener(
-    origin.current.onBeforeRequest,
-    {
-      urls: [`http://${fqdn}/*`, `https://${fqdn}/*`],
-      types: NON_FRAME_TYPES,
-    },
-    ["blocking"],
-  );
-
-  browser.webRequest.onBeforeSendHeaders.addListener(
-    origin.current.onBeforeSendHeaders,
-    {
-      urls: [`http://${fqdn}/*`, `https://${fqdn}/*`],
-      types: ["script"],
-    },
-    ["blocking", "requestHeaders"],
-  );
-
-  browser.webRequest.onHeadersReceived.addListener(
-    origin.current.onHeadersReceived,
-    {
-      urls: [`http://${fqdn}/*`, `https://${fqdn}/*`],
-      types: NON_FRAME_TYPES,
-    },
-    ["blocking", "responseHeaders"],
-  );
 
   return;
 

--- a/extension/src/webcat/update.ts
+++ b/extension/src/webcat/update.ts
@@ -15,6 +15,7 @@ import {
 import validator_set from "../validator_set.json";
 import { WebcatDatabase } from "./db";
 import { hexToUint8Array, Uint8ArrayToBase64 } from "./encoding";
+import { installEnrolledListeners } from "./listeners";
 import { arraysEqual } from "./utils";
 
 let lastUpdateFailed = false;
@@ -187,6 +188,15 @@ export async function update(
       await db.setLastUpdated();
     }
     console.log(`[webcat] List updated successfully`);
+
+    try {
+      await installEnrolledListeners(db);
+    } catch (error) {
+      console.error(
+        "[webcat] Failed to refresh enrolled listeners after update:",
+        error,
+      );
+    }
 
     // Success - clear failure flag
     lastUpdateFailed = false;

--- a/extension/tests/webcat/update.test.ts
+++ b/extension/tests/webcat/update.test.ts
@@ -36,6 +36,8 @@ vi.mock("@freedomofpress/ics23/dist/webcat", () => ({
 vi.mock("../../src/webcat/encoding", () => ({
   hexToUint8Array: vi.fn(() => new Uint8Array([1, 2, 3])),
   Uint8ArrayToBase64: vi.fn(() => "AQID"),
+  stringToUint8Array: vi.fn((s: string) => new TextEncoder().encode(s)),
+  Uint8ArrayToBase64Url: vi.fn(() => "AQID"),
 }));
 
 vi.mock("../../src/webcat/utils", () => ({


### PR DESCRIPTION
Attempt at fixing https://github.com/freedomofpress/webcat/issues/133. As described in the ticket, this approach adds a global listener, loading all the enrolled domains from the database. To my understanding, it should be ok until a few thousands enrollment, at which we should re-evaluate. It also wouldn't be reusable for Onion domains, as we wouldn't know the plaintext of them.

I've been delayed a bit because I am still getting occasional test failures which root cause I haven't fully understood.