### PR TITLE
Fix cross-tab race of origin validation

### DIFF
--- a/extension/src/config.ts
+++ b/extension/src/config.ts
@@ -1,9 +1,11 @@
+declare const __IS_TESTING__: boolean;
+
 export const enrollment_name = "/.well-known/webcat/enrollment.json";
 export const manifest_name = "/.well-known/webcat/manifest.json";
 export const bundle_name = "/.well-known/webcat/bundle.json";
 export const bundle_prev_name = "/.well-known/webcat/bundle-prev.json";
 // Here it's full metadata, potentially with 100kb of manifests each
-export const lru_cache_size = 32;
+export const lru_cache_size = __IS_TESTING__ ? 2 : 32;
 // Items here are just the size in bytes for a domain
 export const lru_set_size = 8192;
 export const endpoint = "https://webcat.freedom.press/";

--- a/extension/src/globals.ts
+++ b/extension/src/globals.ts
@@ -5,6 +5,7 @@ import { stringToUint8Array, Uint8ArrayToBase64Url } from "./webcat/encoding";
 import { OriginStateHolder } from "./webcat/interfaces/originstate";
 
 export const origins = new LRUCache<string, OriginStateHolder>(lru_set_size);
+export const pendingOrigins: Map<string, OriginStateHolder> = new Map();
 export const nonOrigins = new LRUSet<string>(lru_cache_size);
 export const tabs: Map<number, string> = new Map();
 export const db = new WebcatDatabase();

--- a/extension/src/globals.ts
+++ b/extension/src/globals.ts
@@ -4,9 +4,9 @@ import { WebcatDatabase } from "./webcat/db";
 import { stringToUint8Array, Uint8ArrayToBase64Url } from "./webcat/encoding";
 import { OriginStateHolder } from "./webcat/interfaces/originstate";
 
-export const origins = new LRUCache<string, OriginStateHolder>(lru_set_size);
+export const origins = new LRUCache<string, OriginStateHolder>(lru_cache_size);
 export const pendingOrigins: Map<string, OriginStateHolder> = new Map();
-export const nonOrigins = new LRUSet<string>(lru_cache_size);
+export const nonOrigins = new LRUSet<string>(lru_set_size);
 export const tabs: Map<number, string> = new Map();
 export const db = new WebcatDatabase();
 export const hookMarker = stringToUint8Array(

--- a/extension/src/webcat/interfaces/base.ts
+++ b/extension/src/webcat/interfaces/base.ts
@@ -1,6 +1,7 @@
 export enum metadataRequestSource {
   main_frame,
   sub_frame,
+  sub_resource,
   worker,
 }
 

--- a/extension/src/webcat/interfaces/originstate.ts
+++ b/extension/src/webcat/interfaces/originstate.ts
@@ -98,6 +98,8 @@ export class BundleFetcher implements Iterable<BundleFetch> {
 }
 
 export class OriginStateHolder {
+  public stale: boolean = false;
+
   constructor(
     public current:
       | OriginStateBase

--- a/extension/src/webcat/listeners.ts
+++ b/extension/src/webcat/listeners.ts
@@ -22,6 +22,9 @@ import { retryUpdateIfFailed } from "./update";
 import { getFQDN, isExtensionRequest, isNewerSemver } from "./utils";
 
 function commitVerifiedOrigin(fqdn: string, holder: OriginStateHolder): void {
+  if (holder.stale) {
+    return;
+  }
   if (holder.current.status !== "verified_manifest") {
     return;
   }
@@ -96,13 +99,8 @@ export async function headersListener(
     return {};
   }
 
-  // We checked for enrollment back when the request was fired
-  // For tabs only we could do this, but for workers nope
-  //const fqdn = tabs.get(details.tabId);
-  // So instead let's get that again
-
-  let originStateHolder =
-    pendingOrigins.get(details.requestId) ?? origins.get(fqdn);
+  // pendingOrigins is populated by requestListener
+  let originStateHolder = pendingOrigins.get(details.requestId);
 
   if (!originStateHolder) {
     // We are dealing with a background request, probably a serviceworker
@@ -274,25 +272,21 @@ export async function requestListener(
     }
   }
 
-  /* DEVELOPMENT GUARD */
-  /*it's here for development: meaning if we reach this stage
-    and the fqdn is enrolled, but neither a verified origin entry exists nor an in-progress
-    one has been stashed, there is a critical security bug */
-  if (
-    (await db.getFQDNEnrollment(fqdn)).length !== 0 &&
-    !origins.has(fqdn) &&
-    !pendingOrigins.has(details.requestId)
-  ) {
-    console.error(
-      "FATAL: loading from an enrolled origin but the state does not exists.",
-    );
-    return { cancel: true };
+  // Resolve the holder once for the lifetime of this request
+  let originStateHolder = pendingOrigins.get(details.requestId);
+  if (!originStateHolder) {
+    originStateHolder = origins.get(fqdn);
+    if (originStateHolder) {
+      pendingOrigins.set(details.requestId, originStateHolder);
+    }
   }
-  /* END */
 
   // if we know the tab is enrolled, or it is a worker background connction then we should verify
-  if (tabs.has(details.tabId) === true || details.tabId < 0) {
-    await validateResponseContent(details);
+  if (
+    (tabs.has(details.tabId) === true || details.tabId < 0) &&
+    originStateHolder
+  ) {
+    await validateResponseContent(details, originStateHolder);
   }
 
   // See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/BlockingResponse
@@ -300,8 +294,15 @@ export async function requestListener(
   return {};
 }
 
+// Ensure pending objects do not leak
 function errorOccurredListener(
   details: browser.webRequest._OnErrorOccurredDetails,
+): void {
+  pendingOrigins.delete(details.requestId);
+}
+
+function completedListener(
+  details: browser.webRequest._OnCompletedDetails,
 ): void {
   pendingOrigins.delete(details.requestId);
 }
@@ -321,6 +322,7 @@ type RegisteredListeners = {
     details: browser.webRequest._OnHeadersReceivedDetails,
   ) => Promise<browser.webRequest.BlockingResponse>;
   errorOccurred?: (details: browser.webRequest._OnErrorOccurredDetails) => void;
+  completed?: (details: browser.webRequest._OnCompletedDetails) => void;
 };
 
 let currentListeners: RegisteredListeners = {};
@@ -349,6 +351,9 @@ function removeListeners(listeners: RegisteredListeners): void {
   if (listeners.errorOccurred) {
     browser.webRequest.onErrorOccurred.removeListener(listeners.errorOccurred);
   }
+  if (listeners.completed) {
+    browser.webRequest.onCompleted.removeListener(listeners.completed);
+  }
 }
 
 export async function installEnrolledListeners(
@@ -367,7 +372,8 @@ export async function installEnrolledListeners(
       currentListeners.before ||
       currentListeners.beforeHeaders ||
       currentListeners.headers ||
-      currentListeners.errorOccurred
+      currentListeners.errorOccurred ||
+      currentListeners.completed
     ) {
       removeListeners(currentListeners);
       currentListeners = {};
@@ -389,6 +395,8 @@ export async function installEnrolledListeners(
     headersListener(details);
   const errorOccurred = (details: browser.webRequest._OnErrorOccurredDetails) =>
     errorOccurredListener(details);
+  const completed = (details: browser.webRequest._OnCompletedDetails) =>
+    completedListener(details);
 
   // Add new listeners first, then remove the old ones
   browser.webRequest.onBeforeRequest.addListener(before, { urls }, [
@@ -404,9 +412,16 @@ export async function installEnrolledListeners(
     "responseHeaders",
   ]);
   browser.webRequest.onErrorOccurred.addListener(errorOccurred, { urls });
+  browser.webRequest.onCompleted.addListener(completed, { urls });
 
   const previous = currentListeners;
-  currentListeners = { before, beforeHeaders, headers, errorOccurred };
+  currentListeners = {
+    before,
+    beforeHeaders,
+    headers,
+    errorOccurred,
+    completed,
+  };
   removeListeners(previous);
 
   // See https://github.com/freedomofpress/webcat/issues/137

--- a/extension/src/webcat/listeners.ts
+++ b/extension/src/webcat/listeners.ts
@@ -1,9 +1,13 @@
 import { endpoint } from "../config";
-import { db, origins, tabs } from "../globals";
+import { db, origins, pendingOrigins, tabs } from "../globals";
 import type { WebcatDatabase } from "./db";
 import { getHooks } from "./genhooks";
 import { hooksType, metadataRequestSource } from "./interfaces/base";
 import { WebcatError } from "./interfaces/errors";
+import {
+  OriginStateHolder,
+  OriginStateVerifiedManifest,
+} from "./interfaces/originstate";
 import { logger } from "./logger";
 import { validateOrigin } from "./request";
 import { FRAME_TYPES } from "./resources";
@@ -15,7 +19,24 @@ import {
 } from "./response";
 import { errorpage } from "./ui";
 import { retryUpdateIfFailed } from "./update";
-import { getFQDN, isExtensionRequest } from "./utils";
+import { getFQDN, isExtensionRequest, isNewerSemver } from "./utils";
+
+function commitVerifiedOrigin(fqdn: string, holder: OriginStateHolder): void {
+  if (holder.current.status !== "verified_manifest") {
+    return;
+  }
+  const incoming = (holder.current as OriginStateVerifiedManifest).manifest
+    .version;
+  const existing = origins.get(fqdn);
+  if (existing && existing.current.status === "verified_manifest") {
+    const current = (existing.current as OriginStateVerifiedManifest).manifest
+      .version;
+    if (!isNewerSemver(incoming, current)) {
+      return;
+    }
+  }
+  origins.set(fqdn, holder);
+}
 
 function cleanup(tabId: number) {
   if (tabs.has(tabId)) {
@@ -27,14 +48,11 @@ function cleanup(tabId: number) {
         "When deleting a tab, we found an enrolled tab with fqdn",
       );
     }
-    const originState = origins.get(fqdn);
-    if (!originState) {
-      throw new Error(
-        "When deleting a tab, we found an enrolled tab with no associated originState",
-      );
-    }
     /* END */
-    originState.current.references--;
+    const originState = origins.get(fqdn);
+    if (originState) {
+      originState.current.references--;
+    }
     tabs.delete(tabId);
   }
 }
@@ -83,7 +101,10 @@ export async function headersListener(
   //const fqdn = tabs.get(details.tabId);
   // So instead let's get that again
 
-  if (!origins.has(fqdn)) {
+  let originStateHolder =
+    pendingOrigins.get(details.requestId) ?? origins.get(fqdn);
+
+  if (!originStateHolder) {
     // We are dealing with a background request, probably a serviceworker
     logger.addLog(
       "info",
@@ -96,16 +117,16 @@ export async function headersListener(
       details.url,
       details.tabId,
       metadataRequestSource.worker,
+      details.requestId,
     );
     if (result instanceof WebcatError) {
-      origins.delete(fqdn);
+      pendingOrigins.delete(details.requestId);
       tabs.delete(details.tabId);
       errorpage(details.tabId, fqdn, result);
       return { cancel: true };
     }
+    originStateHolder = pendingOrigins.get(details.requestId);
   }
-
-  const originStateHolder = origins.get(fqdn);
 
   if (!originStateHolder) {
     throw new Error("No originState while starting to parse response.");
@@ -119,10 +140,15 @@ export async function headersListener(
       details.tabId,
       fqdn,
     );
-    origins.delete(fqdn);
+    pendingOrigins.delete(details.requestId);
     tabs.delete(details.tabId);
     errorpage(details.tabId, fqdn, result);
     return { cancel: true };
+  }
+
+  if (pendingOrigins.has(details.requestId)) {
+    commitVerifiedOrigin(fqdn, originStateHolder);
+    pendingOrigins.delete(details.requestId);
   }
 
   markResponseContent(details);
@@ -234,9 +260,10 @@ export async function requestListener(
       details.url,
       details.tabId,
       metadataRequestSource.main_frame,
+      details.requestId,
     );
     if (result instanceof WebcatError) {
-      origins.delete(fqdn);
+      pendingOrigins.delete(details.requestId);
       tabs.delete(details.tabId);
       errorpage(details.tabId, fqdn, result);
       return { cancel: true };
@@ -249,8 +276,13 @@ export async function requestListener(
 
   /* DEVELOPMENT GUARD */
   /*it's here for development: meaning if we reach this stage
-    and the fqdn is enrolled, but a entry in the origin map has nor been created, there is a critical security bug */
-  if ((await db.getFQDNEnrollment(fqdn)).length !== 0 && !origins.has(fqdn)) {
+    and the fqdn is enrolled, but neither a verified origin entry exists nor an in-progress
+    one has been stashed, there is a critical security bug */
+  if (
+    (await db.getFQDNEnrollment(fqdn)).length !== 0 &&
+    !origins.has(fqdn) &&
+    !pendingOrigins.has(details.requestId)
+  ) {
     console.error(
       "FATAL: loading from an enrolled origin but the state does not exists.",
     );
@@ -268,6 +300,12 @@ export async function requestListener(
   return {};
 }
 
+function errorOccurredListener(
+  details: browser.webRequest._OnErrorOccurredDetails,
+): void {
+  pendingOrigins.delete(details.requestId);
+}
+
 // Single global webRequest listener registration that scopes to the union
 // of currently enrolled FQDNs. We re-register the listeners on every list
 // update; we always add the new listener before removing the old one, so
@@ -282,6 +320,7 @@ type RegisteredListeners = {
   headers?: (
     details: browser.webRequest._OnHeadersReceivedDetails,
   ) => Promise<browser.webRequest.BlockingResponse>;
+  errorOccurred?: (details: browser.webRequest._OnErrorOccurredDetails) => void;
 };
 
 let currentListeners: RegisteredListeners = {};
@@ -307,6 +346,9 @@ function removeListeners(listeners: RegisteredListeners): void {
   if (listeners.headers) {
     browser.webRequest.onHeadersReceived.removeListener(listeners.headers);
   }
+  if (listeners.errorOccurred) {
+    browser.webRequest.onErrorOccurred.removeListener(listeners.errorOccurred);
+  }
 }
 
 export async function installEnrolledListeners(
@@ -324,7 +366,8 @@ export async function installEnrolledListeners(
     if (
       currentListeners.before ||
       currentListeners.beforeHeaders ||
-      currentListeners.headers
+      currentListeners.headers ||
+      currentListeners.errorOccurred
     ) {
       removeListeners(currentListeners);
       currentListeners = {};
@@ -344,6 +387,8 @@ export async function installEnrolledListeners(
   ) => beforeHeadersListener(details);
   const headers = (details: browser.webRequest._OnHeadersReceivedDetails) =>
     headersListener(details);
+  const errorOccurred = (details: browser.webRequest._OnErrorOccurredDetails) =>
+    errorOccurredListener(details);
 
   // Add new listeners first, then remove the old ones
   browser.webRequest.onBeforeRequest.addListener(before, { urls }, [
@@ -358,9 +403,10 @@ export async function installEnrolledListeners(
     "blocking",
     "responseHeaders",
   ]);
+  browser.webRequest.onErrorOccurred.addListener(errorOccurred, { urls });
 
   const previous = currentListeners;
-  currentListeners = { before, beforeHeaders, headers };
+  currentListeners = { before, beforeHeaders, headers, errorOccurred };
   removeListeners(previous);
 
   // See https://github.com/freedomofpress/webcat/issues/137

--- a/extension/src/webcat/listeners.ts
+++ b/extension/src/webcat/listeners.ts
@@ -225,6 +225,10 @@ export async function beforeHeadersListener(
 export async function requestListener(
   details: browser.webRequest._OnBeforeRequestDetails,
 ): Promise<browser.webRequest.BlockingResponse> {
+  if (isExtensionRequest(details)) {
+    return {};
+  }
+
   const fqdn = getFQDN(details.url);
 
   const isFrame = FRAME_TYPES.includes(details.type);

--- a/extension/src/webcat/listeners.ts
+++ b/extension/src/webcat/listeners.ts
@@ -227,21 +227,12 @@ export async function requestListener(
 ): Promise<browser.webRequest.BlockingResponse> {
   const fqdn = getFQDN(details.url);
 
-  if (
-    (details.tabId < 0 && !origins.has(fqdn)) ||
-    isExtensionRequest(details)
-  ) {
-    // TODO: is this still relevant? it seems like it
-    // should apply to workers (no tab id) if they do
-    // a fetch request and the origin doesn't exists
-    // To be safe maybe we should check for enrollment again?
-    return {};
-  }
+  const isFrame = FRAME_TYPES.includes(details.type);
 
-  // TODO: why does this happen for sub_frames?
-  //if (details.type === "main_frame" || details.type === "sub_frame") {
-  if (FRAME_TYPES.includes(details.type)) {
-    // User is navigatin to a new context, whether is enrolled or not better to reset
+  // Frame-only pre-setup: reset the tab's origin state and retry pending
+  // list updates
+  if (isFrame) {
+    // User is navigating to a new context, whether is enrolled or not better to reset
     cleanup(details.tabId);
 
     logger.addLog(
@@ -252,45 +243,50 @@ export async function requestListener(
     );
 
     await retryUpdateIfFailed(db, endpoint);
-
-    const result = await validateOrigin(
-      fqdn,
-      details.url,
-      details.tabId,
-      metadataRequestSource.main_frame,
-      details.requestId,
-    );
-    if (result instanceof WebcatError) {
-      pendingOrigins.delete(details.requestId);
-      tabs.delete(details.tabId);
-      errorpage(details.tabId, fqdn, result);
-      return { cancel: true };
-    }
-    if (result) {
-      logger.addLog("info", `Redirecting to https`, details.tabId, fqdn);
-      return result;
-    }
   }
 
-  // Resolve the holder once for the lifetime of this request
-  let originStateHolder = pendingOrigins.get(details.requestId);
-  if (!originStateHolder) {
+  let originStateHolder: OriginStateHolder | undefined;
+  if (!isFrame) {
     originStateHolder = origins.get(fqdn);
     if (originStateHolder) {
       pendingOrigins.set(details.requestId, originStateHolder);
     }
   }
 
-  // if we know the tab is enrolled, or it is a worker background connction then we should verify
-  if (
-    (tabs.has(details.tabId) === true || details.tabId < 0) &&
-    originStateHolder
-  ) {
-    await validateResponseContent(details, originStateHolder);
+  if (!originStateHolder) {
+    const result = await validateOrigin(
+      fqdn,
+      details.url,
+      details.tabId,
+      isFrame
+        ? metadataRequestSource.main_frame
+        : metadataRequestSource.sub_resource,
+      details.requestId,
+    );
+    if (result instanceof WebcatError) {
+      pendingOrigins.delete(details.requestId);
+      if (isFrame) {
+        tabs.delete(details.tabId);
+        errorpage(details.tabId, fqdn, result);
+      }
+      return { cancel: true };
+    }
+    if (result) {
+      // HTTPS redirect; browser reissues under a fresh requestId.
+      if (isFrame) {
+        logger.addLog("info", `Redirecting to https`, details.tabId, fqdn);
+      }
+      return result;
+    }
+    originStateHolder = pendingOrigins.get(details.requestId);
   }
 
-  // See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/BlockingResponse
-  // Returning a response here is a very powerful tool, let's think about it later
+  // No holder means the fqdn isn't enrolled
+  if (!originStateHolder) {
+    return {};
+  }
+
+  await validateResponseContent(details, originStateHolder);
   return {};
 }
 

--- a/extension/src/webcat/request.ts
+++ b/extension/src/webcat/request.ts
@@ -1,4 +1,4 @@
-import { origins, tabs } from "./../globals";
+import { origins, pendingOrigins, tabs } from "./../globals";
 import { db } from "./../globals";
 import { metadataRequestSource } from "./interfaces/base";
 import { WebcatError, WebcatErrorCode } from "./interfaces/errors";
@@ -16,6 +16,7 @@ export async function validateOrigin(
   url: string,
   tabId: number,
   type: metadataRequestSource,
+  requestId: string,
 ) {
   const enrollment_hash = await db.getFQDNEnrollment(fqdn);
   if (enrollment_hash.length === 0) {
@@ -47,10 +48,7 @@ export async function validateOrigin(
     tabs.set(tabId, fqdn);
   }
 
-  // If origin metadata are already loaded, just skip doing it again and return early
-  const originStateHolder = origins.get(fqdn);
-  if (originStateHolder) {
-    // Since we use cached info, we should still populate the popup with the cached info
+  if (origins.get(fqdn)) {
     return;
   }
 
@@ -74,7 +72,7 @@ export async function validateOrigin(
     enrollment_hash,
   );
   const origin = new OriginStateHolder(newOriginState);
-  origins.set(fqdn, origin);
+  pendingOrigins.set(requestId, origin);
 
   // See https://github.com/freedomofpress/webcat/issues/95
   await origin.current.fetcher.awaitAll();

--- a/extension/src/webcat/request.ts
+++ b/extension/src/webcat/request.ts
@@ -48,7 +48,10 @@ export async function validateOrigin(
     tabs.set(tabId, fqdn);
   }
 
-  if (origins.get(fqdn)) {
+  const cached = origins.get(fqdn);
+  if (cached) {
+    // Pin the holder to this request so later stages cannot race against LRU eviction
+    pendingOrigins.set(requestId, cached);
     return;
   }
 

--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -1,4 +1,4 @@
-import { endMarker, hookMarker, origins } from "./../globals";
+import { endMarker, hookMarker, origins, pendingOrigins } from "./../globals";
 import {
   base64UrlToUint8Array,
   stringToUint8Array,
@@ -139,6 +139,10 @@ export async function validateResponseHeaders(
       fqdn,
     );
     origins.delete(fqdn);
+    // Mark the holder so any sibling request that shares it won't re-insert
+    // it via commitVerifiedOrigin later
+    originStateHolder.stale = true;
+    pendingOrigins.delete(details.requestId);
     browser.tabs.reload(details.tabId, { bypassCache: true });
   }
 
@@ -180,22 +184,22 @@ export async function validateResponseHeaders(
   }
 }
 
-function getVerifiedManifestState(fqdn: string): OriginStateHolder {
-  const origin = origins.get(fqdn);
+function assertVerifiedManifest(
+  holder: OriginStateHolder,
+): asserts holder is OriginStateHolder & {
+  current: OriginStateVerifiedManifest;
+} {
   if (
-    !origin ||
-    origin.current.status !== "verified_manifest" ||
-    !(origin.current as OriginStateVerifiedManifest).manifest
+    holder.current.status !== "verified_manifest" ||
+    !(holder.current as OriginStateVerifiedManifest).manifest
   ) {
     throw new Error("origin is not populated when it was expected");
   }
-  return origin as OriginStateHolder & {
-    current: OriginStateVerifiedManifest;
-  };
 }
 
 export async function validateResponseContent(
   details: browser.webRequest._OnBeforeRequestDetails,
+  originStateHolder: OriginStateHolder,
 ) {
   function deny(filter: browser.webRequest.StreamFilter) {
     // DENIED
@@ -205,17 +209,13 @@ export async function validateResponseContent(
   const pathname = new URL(details.url).pathname;
   const fqdn = getFQDN(details.url);
 
-  // The goal of doing this both here and after is the following: if a resource
-  // is a media type and not in the manifest we do not want even to start filtering
-  // otherwise large file might be loaded in memory by the extension without
-  // then any real benefit
+  // The holder was pulled from the LRU and is guaranteed to be in
+  // verified_manifest state
   if (NON_FRAME_TYPES.includes(details.type)) {
-    const originStateHolder = getVerifiedManifestState(fqdn);
-    /* Development guard */
-    // This should never happen! if we are here it means that a main or sub_frame is
-    // loading a subresource, and thus origin must be populated!
     const manifest = (originStateHolder.current as OriginStateVerifiedManifest)
       .manifest;
+    // If a pass-through media type isn't in the manifest, bail before installing
+    // a filter so large files don't get buffered into the extension for nothing.
     if (
       !manifest.files[pathname] &&
       !(
@@ -228,13 +228,11 @@ export async function validateResponseContent(
     }
   }
 
-  let originStateHolder: OriginStateHolder;
-  let manifest: Manifest;
+  let manifest!: Manifest;
   const filter = browser.webRequest.filterResponseData(details.requestId);
   filter.onstart = () => {
-    originStateHolder = getVerifiedManifestState(fqdn);
-    manifest = (originStateHolder.current as OriginStateVerifiedManifest)
-      .manifest;
+    assertVerifiedManifest(originStateHolder);
+    manifest = originStateHolder.current.manifest;
   };
 
   const source: ArrayBuffer[] = [];

--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -209,9 +209,10 @@ export async function validateResponseContent(
   const pathname = new URL(details.url).pathname;
   const fqdn = getFQDN(details.url);
 
-  // The holder was pulled from the LRU and is guaranteed to be in
-  // verified_manifest state
-  if (NON_FRAME_TYPES.includes(details.type)) {
+  if (
+    NON_FRAME_TYPES.includes(details.type) &&
+    originStateHolder.current.status === "verified_manifest"
+  ) {
     const manifest = (originStateHolder.current as OriginStateVerifiedManifest)
       .manifest;
     // If a pass-through media type isn't in the manifest, bail before installing

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -31,6 +31,9 @@ export default defineConfig({
         },
       }
     : {},
+  define: {
+    __IS_TESTING__: isTesting,
+  },
   plugins: [viteSingleFile()],
   test: {
     globals: true,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -24,6 +24,7 @@ _tbb_safest_skips = {
     "corrupted_sharedworker_test": "JavaScript fully disabled at this security level",
     "corrupted_audioworklet_test": "JavaScript fully disabled at this security level",
     "corrupted_js_with_induced_error_test": "JavaScript fully disabled at this security level",
+    "non_enrolled_loads_enrolled_subresource_test": "JavaScript fully disabled at this security level",
 }
 _browser_skips = {
     "tbb": _tbb_skips,
@@ -73,9 +74,15 @@ def dnsnames():
     ]
 
 @pytest.fixture(scope="session")
-def ssl_cert(dnsnames):
+def non_enrolled_dnsnames():
+    return [
+        "nonenrolled.localhost",
+    ]
+
+@pytest.fixture(scope="session")
+def ssl_cert(dnsnames, non_enrolled_dnsnames):
     tmpdir = tempfile.mkdtemp()
-    cert_path, key_path = generate_ssl_cert(tmpdir, dnsnames)
+    cert_path, key_path = generate_ssl_cert(tmpdir, dnsnames + non_enrolled_dnsnames)
     return cert_path, key_path
 
 @pytest.fixture(scope="session")
@@ -111,7 +118,7 @@ def server(root, headers, hooks, ssl_cert):
     s.stop()
 
 @pytest.fixture(scope="function")
-def browser(request, ssl_cert, server, dnsnames):
+def browser(request, ssl_cert, server, dnsnames, non_enrolled_dnsnames):
     cert_path, _ = ssl_cert
     if request.param == "firefox":
         b = Browser()
@@ -123,7 +130,7 @@ def browser(request, ssl_cert, server, dnsnames):
         b = TorBrowser(allowed_addons=["webcat@freedom.press"], security_level=TorBrowser.SecurityLevel.Safest)
     else:
         raise RuntimeError(f'unrecognized browser \'{request.param}\'')
-    b.trust_cert(cert_path, server.port, dnsnames)
+    b.trust_cert(cert_path, server.port, dnsnames + non_enrolled_dnsnames)
     b.start(request.config.getoption("--headless"))
     yield b
     b.destroy()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -66,9 +66,16 @@ def addon_path(request):
     return abs_path
 
 @pytest.fixture(scope="session")
-def ssl_cert():
+def dnsnames():
+    return [
+        "site1.localhost",
+        "site2.localhost",
+    ]
+
+@pytest.fixture(scope="session")
+def ssl_cert(dnsnames):
     tmpdir = tempfile.mkdtemp()
-    cert_path, key_path = generate_ssl_cert(tmpdir)
+    cert_path, key_path = generate_ssl_cert(tmpdir, dnsnames)
     return cert_path, key_path
 
 @pytest.fixture(scope="session")
@@ -78,13 +85,15 @@ def db():
     return db
 
 @pytest.fixture(scope="session")
-def root(db, request):
+def root(db, dnsnames, request):
     generate_bundle(request.param)
     with open(f'{request.param}/.well-known/webcat/bundle.json') as bundle:
         enrollment = json.load(bundle)["enrollment"]
         canonical_enrollment = canonicaljson.encode_canonical_json(enrollment)
         enrollment_hash = hashlib.sha256(canonical_enrollment).hexdigest()
         db.set("127.0.0.1", enrollment_hash)
+        for name in dnsnames:
+            db.set(name, enrollment_hash)
     return request.param
 
 @pytest.fixture(scope="function")
@@ -102,7 +111,7 @@ def server(root, headers, hooks, ssl_cert):
     s.stop()
 
 @pytest.fixture(scope="function")
-def browser(request, ssl_cert, server):
+def browser(request, ssl_cert, server, dnsnames):
     cert_path, _ = ssl_cert
     if request.param == "firefox":
         b = Browser()
@@ -114,7 +123,7 @@ def browser(request, ssl_cert, server):
         b = TorBrowser(allowed_addons=["webcat@freedom.press"], security_level=TorBrowser.SecurityLevel.Safest)
     else:
         raise RuntimeError(f'unrecognized browser \'{request.param}\'')
-    b.trust_cert(cert_path, server.port)
+    b.trust_cert(cert_path, server.port, dnsnames)
     b.start(request.config.getoption("--headless"))
     yield b
     b.destroy()

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -86,7 +86,7 @@ class Browser:
         except:
             pass
 
-    def trust_cert(self, cert_path, port):
+    def trust_cert(self, cert_path, port, dnsnames = []):
         """Add a certificate override for 127.0.0.1:port via cert_override.txt."""
         with open(cert_path, "rb") as f:
             cert = x509.load_pem_x509_certificate(f.read())
@@ -97,6 +97,8 @@ class Browser:
         override_file = self.profile_path / "cert_override.txt"
         with open(override_file, "a") as f:
             f.write(f"127.0.0.1:{port}\tOID.2.16.840.1.101.3.4.2.1\t{fingerprint}\t{db_key}\n")
+            for name in dnsnames:
+                f.write(f"{name}:{port}\tOID.2.16.840.1.101.3.4.2.1\t{fingerprint}\t{db_key}\n")
 
     def install_extension(self, path):
         root_actor_ids = self.root.get_root()
@@ -234,6 +236,9 @@ class Hook:
         self.type = type
 
 class Server:
+    class MultiThreadedServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+        pass
+
     def __init__(self, root=".", headers=None, hooks=None, ssl_cert=None, ssl_key=None):
         self.root = os.path.abspath(root)
         self.headers = headers or {}
@@ -274,7 +279,7 @@ class Server:
 
             def log_message(self, *a): pass  # suppress logs
 
-        self.httpd = socketserver.TCPServer(("127.0.0.1", 0), Handler)
+        self.httpd = Server.MultiThreadedServer(("127.0.0.1", 0), Handler)
         if self.ssl_cert and self.ssl_key:
             context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
             context.load_cert_chain(self.ssl_cert, self.ssl_key)
@@ -291,10 +296,12 @@ class Server:
         scheme = "https" if self.ssl_cert else "http"
         return f"{scheme}://127.0.0.1:{self.port}"
 
-def generate_ssl_cert(output_dir):
+def generate_ssl_cert(output_dir, dnsnames=[]):
     """Generate a self-signed certificate for 127.0.0.1."""
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "127.0.0.1")])
+    names = [x509.IPAddress(ipaddress.IPv4Address("127.0.0.1"))]
+    names.extend(map(lambda name: x509.DNSName(name), dnsnames))
     cert = (
         x509.CertificateBuilder()
         .subject_name(subject)
@@ -303,10 +310,7 @@ def generate_ssl_cert(output_dir):
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
         .not_valid_after(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1))
-        .add_extension(
-            x509.SubjectAlternativeName([x509.IPAddress(ipaddress.IPv4Address("127.0.0.1"))]),
-            critical=False,
-        )
+        .add_extension(x509.SubjectAlternativeName(names), critical=False)
         .sign(key, hashes.SHA256())
     )
     cert_path = os.path.join(output_dir, "cert.pem")

--- a/test/tests.py
+++ b/test/tests.py
@@ -258,10 +258,11 @@ def test_multiple_tabs(browser: Browser, server: Server, expected, addon_path):
 ], indirect=["root"], ids=[
     "non_enrolled_loads_enrolled_subresource_test",
 ])
-def test_non_enrolled_subresource(browser: Browser, server: Server, expected, addon_path, non_enrolled_dnsnames):
-    enrolled_url = server.url()
+def test_non_enrolled_subresource(browser: Browser, server: Server, expected, addon_path, dnsnames, non_enrolled_dnsnames):
+    enrolled_url = server.url().replace("127.0.0.1", dnsnames[0])
+    non_enrolled_url = server.url().replace("127.0.0.1", non_enrolled_dnsnames[0])
     # Non-enrolled landing page that loads a single sub-resource cross-origin
-    # from the enrolled domain
+    # from the enrolled domain.
     server.hooks["/"] = Hook(
         b'<!DOCTYPE html><html><body>'
         b'<p>non-enrolled</p>'
@@ -272,7 +273,6 @@ def test_non_enrolled_subresource(browser: Browser, server: Server, expected, ad
     )
     browser.install_extension(addon_path)
     sleep(7)
-    non_enrolled_url = enrolled_url.replace("127.0.0.1", non_enrolled_dnsnames[0])
     browser.navigate(non_enrolled_url)
     sleep(5)
     res = browser.execute("document.body.innerText")

--- a/test/tests.py
+++ b/test/tests.py
@@ -246,3 +246,35 @@ def test_multiple_tabs(browser: Browser, server: Server, expected, addon_path):
     sleep(3)
     res = browser.execute("document.body.innerText")
     assert expected in res
+
+@pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
+@pytest.mark.parametrize("root, headers, hooks, expected", [
+    ("cases/testapp", {
+        "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
+                                   "style-src 'self'; frame-src 'none'; worker-src 'self';",
+    }, {
+        "/": Hook(open("cases/testapp/index.html", "rb").read(), type="text/html", delay=2),
+        "/js/alert.js": Hook(b"alert('hacked');", type="text/javascript"),
+    }, "ERR_WEBCAT_FILE_MISMATCH"),
+], indirect=["root"], ids=[
+    "corrupted_js_with_cache_eviction_test",
+])
+def test_cache_eviction(browser: Browser, server: Server, expected, addon_path):
+    browser.install_extension(addon_path)
+    sleep(7)
+    sites = [
+        server.url(),
+        server.url().replace("127.0.0.1", "site1.localhost"),
+        server.url().replace("127.0.0.1", "site2.localhost"),
+    ]
+    browser.execute(
+         "const w = window.open();"
+        f"window.open('{sites[0]}');"
+         "setTimeout(() => {"
+        f"    w.location.href = '{sites[1]}/console_log.png';"
+        f"    location.href = '{sites[2]}/console_log.png';"
+         "}, 1000)"
+    )
+    sleep(3)
+    res = browser.execute("document.body.innerText")
+    assert expected in res

--- a/test/tests.py
+++ b/test/tests.py
@@ -253,6 +253,36 @@ def test_multiple_tabs(browser: Browser, server: Server, expected, addon_path):
         "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
                                    "style-src 'self'; frame-src 'none'; worker-src 'self';",
     }, {
+        "/js/alert.js": Hook(b"alert('hacked');", type="text/javascript"),
+    }, "ERR_WEBCAT_FILE_MISMATCH"),
+], indirect=["root"], ids=[
+    "non_enrolled_loads_enrolled_subresource_test",
+])
+def test_non_enrolled_subresource(browser: Browser, server: Server, expected, addon_path, non_enrolled_dnsnames):
+    enrolled_url = server.url()
+    # Non-enrolled landing page that loads a single sub-resource cross-origin
+    # from the enrolled domain
+    server.hooks["/"] = Hook(
+        b'<!DOCTYPE html><html><head>'
+        b'<script src="' + enrolled_url.encode() + b'/js/alert.js"></script>'
+        b'</head><body></body></html>',
+        type="text/html",
+        headers={"content-security-policy": "script-src *"},
+    )
+    browser.install_extension(addon_path)
+    sleep(7)
+    non_enrolled_url = enrolled_url.replace("127.0.0.1", non_enrolled_dnsnames[0])
+    browser.navigate(non_enrolled_url)
+    sleep(3)
+    res = browser.execute("document.body.innerText")
+    assert expected in res
+
+@pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
+@pytest.mark.parametrize("root, headers, hooks, expected", [
+    ("cases/testapp", {
+        "content-security-policy": "object-src 'none'; default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
+                                   "style-src 'self'; frame-src 'none'; worker-src 'self';",
+    }, {
         "/": Hook(open("cases/testapp/index.html", "rb").read(), type="text/html", delay=2),
         "/js/alert.js": Hook(b"alert('hacked');", type="text/javascript"),
     }, "ERR_WEBCAT_FILE_MISMATCH"),

--- a/test/tests.py
+++ b/test/tests.py
@@ -263,9 +263,10 @@ def test_non_enrolled_subresource(browser: Browser, server: Server, expected, ad
     # Non-enrolled landing page that loads a single sub-resource cross-origin
     # from the enrolled domain
     server.hooks["/"] = Hook(
-        b'<!DOCTYPE html><html><head>'
+        b'<!DOCTYPE html><html><body>'
+        b'<p>non-enrolled</p>'
         b'<script src="' + enrolled_url.encode() + b'/js/alert.js"></script>'
-        b'</head><body></body></html>',
+        b'</body></html>',
         type="text/html",
         headers={"content-security-policy": "script-src *"},
     )
@@ -273,7 +274,7 @@ def test_non_enrolled_subresource(browser: Browser, server: Server, expected, ad
     sleep(7)
     non_enrolled_url = enrolled_url.replace("127.0.0.1", non_enrolled_dnsnames[0])
     browser.navigate(non_enrolled_url)
-    sleep(3)
+    sleep(5)
     res = browser.execute("document.body.innerText")
     assert expected in res
 


### PR DESCRIPTION
Attempt at fixing https://github.com/freedomofpress/webcat/issues/170. Create temporary origins object in a new global object, `pendingOrigins`, keyd per request id, which should be unique. Upon successful validation, promote to `origins` only if a newer version of the currently cached one.