### PR TITLE
Test manifest update logic

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,7 +6,7 @@ import canonicaljson
 import hashlib
 
 from helpers import Browser, UpdateServer, Server, TorBrowser, generate_ssl_cert
-from sigsum import generate_bundle
+from sigsum import BundleGenerator
 from pytest_benchmark.fixture import BenchmarkFixture
 
 _tbb_skips = {
@@ -106,8 +106,14 @@ def update_server():
     return us
 
 @pytest.fixture(scope="session")
-def root(update_server, dnsnames, request):
-    generate_bundle(request.param)
+def bundle_generator():
+    g = BundleGenerator()
+    yield g
+    g.close()
+
+@pytest.fixture(scope="session")
+def root(update_server, dnsnames, request, bundle_generator):
+    bundle_generator.sign(request.param)
     with open(f'{request.param}/.well-known/webcat/bundle.json') as bundle:
         enrollment = json.load(bundle)["enrollment"]
         canonical_enrollment = canonicaljson.encode_canonical_json(enrollment)

--- a/test/sigsum.py
+++ b/test/sigsum.py
@@ -1,23 +1,33 @@
 from os import makedirs
-from os.path import abspath, join
+from os.path import abspath, dirname, join
 from tempfile import TemporaryDirectory
 from subprocess import run
 
-def generate_bundle(path):
-    path = abspath(path)
-    with TemporaryDirectory() as tmp:
-        run(["sigsum-key", "generate", "-o", "key1"], cwd=tmp, check=True)
-        hex1 = run(["sigsum-key", "to-hex", "-k", "key1.pub"], cwd=tmp, check=True, capture_output=True, text=True)
-        run(["sigsum-key", "generate", "-o", "key2"], cwd=tmp, check=True)
-        hex2 = run(["sigsum-key", "to-hex", "-k", "key2.pub"], cwd=tmp, check=True, capture_output=True, text=True)
-        with open(join(tmp, "trust_policy"), "w", encoding="utf-8") as trust_policy:
-            trust_policy.write("log 4644af2abd40f4895a003bca350f9d5912ab301a49c77f13e5b6d905c20a5fe6 https://test.sigsum.org/barreleye\n")
-            trust_policy.write("\n")
-            trust_policy.write("witness poc.sigsum.org/nisse 1c25f8a44c635457e2e391d1efbca7d4c2951a0aef06225a881e46b98962ac6c\n")
-            trust_policy.write("witness rgdd.se/poc-witness  28c92a5a3a054d317c86fc2eeb6a7ab2054d6217100d0be67ded5b74323c5806\n")
-            trust_policy.write("\n")
-            trust_policy.write("group  demo-quorum-rule any poc.sigsum.org/nisse rgdd.se/poc-witness\n")
-            trust_policy.write("quorum demo-quorum-rule\n")
+TRUST_POLICY = (
+    "log 4644af2abd40f4895a003bca350f9d5912ab301a49c77f13e5b6d905c20a5fe6 https://test.sigsum.org/barreleye\n"
+    "\n"
+    "witness poc.sigsum.org/nisse 1c25f8a44c635457e2e391d1efbca7d4c2951a0aef06225a881e46b98962ac6c\n"
+    "witness rgdd.se/poc-witness  28c92a5a3a054d317c86fc2eeb6a7ab2054d6217100d0be67ded5b74323c5806\n"
+    "\n"
+    "group  demo-quorum-rule any poc.sigsum.org/nisse rgdd.se/poc-witness\n"
+    "quorum demo-quorum-rule\n"
+)
+
+
+class BundleGenerator:
+    """Holds keys and enrollment so multiple bundles can share one enrollment."""
+
+    def __init__(self):
+        self._tmp_ctx = TemporaryDirectory()
+        self.tmp = self._tmp_ctx.name
+        run(["sigsum-key", "generate", "-o", "key1"], cwd=self.tmp, check=True)
+        hex1 = run(["sigsum-key", "to-hex", "-k", "key1.pub"],
+                   cwd=self.tmp, check=True, capture_output=True, text=True)
+        run(["sigsum-key", "generate", "-o", "key2"], cwd=self.tmp, check=True)
+        hex2 = run(["sigsum-key", "to-hex", "-k", "key2.pub"],
+                   cwd=self.tmp, check=True, capture_output=True, text=True)
+        with open(join(self.tmp, "trust_policy"), "w", encoding="utf-8") as f:
+            f.write(TRUST_POLICY)
         run(["webcat", "enrollment", "create",
              "--policy-file", "trust_policy",
              "--threshold", "1",
@@ -26,22 +36,43 @@ def generate_bundle(path):
              "--signer", hex1.stdout,
              "--signer", hex2.stdout,
              "--output", "enrollment.json"],
-             cwd=tmp, check=True)
+            cwd=self.tmp, check=True)
+
+    def sign(self, source_path, config_path=None, output_path=None):
+        """Generate manifest and bundle for content under source_path.
+
+        config_path: webcat.config.json to use (default: source_path/webcat.config.json).
+        output_path: bundle.json destination (default: source_path/.well-known/webcat/bundle.json).
+        """
+        source_path = abspath(source_path)
+        config_path = abspath(config_path) if config_path else join(source_path, "webcat.config.json")
+        output_path = abspath(output_path) if output_path else join(source_path, ".well-known/webcat/bundle.json")
         run(["webcat", "manifest", "generate",
              "--policy-file", "trust_policy",
-             "--config", join(path, "webcat.config.json"),
-             "--directory", path,
+             "--config", config_path,
+             "--directory", source_path,
              "--output", "manifest_unsigned.json"],
-            cwd=tmp, check=True)
+            cwd=self.tmp, check=True)
         run(["webcat", "manifest", "sign",
              "--policy-file", "trust_policy",
              "-i", "manifest_unsigned.json",
              "-k", "key1",
              "-o", "manifest.json"],
-            cwd=tmp, check=True)
-        makedirs(join(path, ".well-known/webcat"), exist_ok=True)
+            cwd=self.tmp, check=True)
+        makedirs(dirname(output_path), exist_ok=True)
         run(["webcat", "bundle", "create",
              "--enrollment", "enrollment.json",
              "--manifest", "manifest.json",
-             "--output", join(path, ".well-known/webcat/bundle.json")],
-            cwd=tmp, check=True)
+             "--output", output_path],
+            cwd=self.tmp, check=True)
+
+    def close(self):
+        self._tmp_ctx.cleanup()
+
+
+def generate_bundle(path):
+    g = BundleGenerator()
+    try:
+        g.sign(path)
+    finally:
+        g.close()

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,3 +1,6 @@
+import os
+import shutil
+import tempfile
 import pytest
 from time import sleep
 from helpers import Browser, Server, Hook
@@ -298,3 +301,55 @@ def test_cache_eviction(browser: Browser, server: Server, expected, addon_path, 
     sleep(3)
     res = browser.execute("document.body.innerText")
     assert expected in res
+
+@pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
+@pytest.mark.parametrize("root, headers, hooks, expected", [
+    pytest.param("cases/testapp", EXPECTED_CSP, {}, "Hello v2!",
+        id="version_refresh_test"),
+], indirect=["root"])
+def test_version_refresh(browser: Browser, server: Server, bundle_generator, expected, addon_path, root):
+    # Load v0.1: server serves the bundle that the `root` fixture signed.
+    browser.install_extension(addon_path)
+    sleep(7)
+    browser.navigate(server.url())
+    sleep(3)
+    assert "Hello!" in browser.execute("document.body.innerText")
+
+    # Build a v0.2 bundle signed with the same enrollment as v0.1, with a
+    # modified index.html. The inline <script> block is left untouched so its
+    # CSP sha256 hash stays valid.
+    with tempfile.TemporaryDirectory() as tmp:
+        v2_dir = os.path.join(tmp, "testapp_v2")
+        shutil.copytree(root, v2_dir)
+        index_path = os.path.join(v2_dir, "index.html")
+        with open(index_path, "r", encoding="utf-8") as f:
+            html = f.read()
+        new_html = html.replace("<p>Hello!</p>", "<p>Hello v2!</p>")
+        assert new_html != html, "index.html marker not found"
+        with open(index_path, "w", encoding="utf-8") as f:
+            f.write(new_html)
+        config_path = os.path.join(v2_dir, "webcat.config.json")
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = json.load(f)
+        config["version"] = "0.2"
+        with open(config_path, "w", encoding="utf-8") as f:
+            json.dump(config, f)
+        v2_bundle_path = os.path.join(tmp, "bundle_v2.json")
+        bundle_generator.sign(v2_dir, output_path=v2_bundle_path)
+        with open(v2_bundle_path, "rb") as f:
+            v2_bundle = f.read()
+        with open(index_path, "rb") as f:
+            v2_index = f.read()
+
+    # Server now signals a new version and serves the v0.2 bundle + content.
+    # The extension should detect x-webcat-version > cached manifest.version,
+    # purge the origin cache, and reload with bypassCache.
+    server.hooks["/"] = Hook(v2_index, type="text/html",
+                             headers={"x-webcat-version": "0.2"})
+    server.hooks["/.well-known/webcat/bundle.json"] = Hook(
+        v2_bundle, type="application/json",
+        headers={"cache-control": "no-store"})
+
+    browser.execute("location.reload()")
+    sleep(5)
+    assert expected in browser.execute("document.body.innerText")


### PR DESCRIPTION
Addresses https://github.com/freedomofpress/webcat/issues/171

Adds an integration test to check websites can signal a new manifets version, and that the extension can load the new one at refresh. There's the practical problem that navigating to the same URL might load from cache and skip the header, while a refresh forces an actual reload to happen. I don't think this is specifically a WEBCAT problem, rather when we write documentations we should just clarify how to handle upgrades in the best way. For instance by either redirecting to a new path (like `?v2`) or, by regularly fetching async and force the refresh from the application itself. Maybe we'll revisit this in the future, but for now the current state is better than nothing.