### PR TITLE
Cleanup delegation and add integration test

### DIFF
--- a/extension/src/webcat/interfaces/originstate.ts
+++ b/extension/src/webcat/interfaces/originstate.ts
@@ -139,12 +139,14 @@ export abstract class OriginStateBase {
     port: string,
     fqdn: string,
     enrollment_hash: Uint8Array,
+    delegation?: string,
   ) {
     this.fetcher = fetcher;
     this.scheme = scheme;
     this.port = port;
     this.fqdn = fqdn;
     this.enrollment_hash = enrollment_hash;
+    this.delegation = delegation;
     this.references = 1;
 
     // Cleanup service workers, see https://github.com/freedomofpress/webcat/issues/18
@@ -167,6 +169,7 @@ export class OriginStateFailed extends OriginStateBase {
       prev.port,
       prev.fqdn,
       prev.enrollment_hash,
+      prev.delegation,
     );
     Object.assign(this, prev);
     // We must set it again because we are copying
@@ -297,7 +300,6 @@ export class OriginStateInitial extends OriginStateBase {
 export class OriginStateVerifiedEnrollment extends OriginStateBase {
   public readonly status = "verified_enrollment" as const;
   public readonly enrollment: Enrollment;
-  public readonly delegation?: string | undefined;
   public bundle?: Bundle;
 
   constructor(
@@ -311,10 +313,10 @@ export class OriginStateVerifiedEnrollment extends OriginStateBase {
       prev.port,
       prev.fqdn,
       prev.enrollment_hash,
+      delegation,
     );
     this.references = prev.references;
     this.enrollment = enrollment;
-    this.delegation = delegation;
     this.bundle = prev.bundle;
   }
 
@@ -416,7 +418,6 @@ export class OriginStateVerifiedEnrollment extends OriginStateBase {
 
 export class OriginStateVerifiedManifest extends OriginStateBase {
   public readonly status = "verified_manifest" as const;
-  public readonly delegation?: string | undefined;
   public readonly enrollment: Enrollment;
   public readonly manifest: Manifest;
   public readonly valid_sources: Set<string> = new Set();
@@ -432,12 +433,12 @@ export class OriginStateVerifiedManifest extends OriginStateBase {
       prev.port,
       prev.fqdn,
       prev.enrollment_hash,
+      prev.delegation,
     );
     this.references = prev.references;
     this.enrollment = prev.enrollment;
     this.manifest = manifest;
     this.valid_sources = valid_sources;
-    this.delegation = prev.delegation;
     this.bundle = prev.bundle;
   }
 

--- a/extension/src/webcat/ui.ts
+++ b/extension/src/webcat/ui.ts
@@ -29,7 +29,14 @@ export function setOKIcon(tabId: number, delegation?: string) {
 
   const theme = isDarkTheme() ? "dark" : "light";
 
-  logger.addLog("debug", "Setting ok icon", tabId, "");
+  logger.addLog(
+    "info",
+    delegation
+      ? `Setting ok icon (delegation: ${delegation})`
+      : "Setting ok icon",
+    tabId,
+    "",
+  );
   browser.pageAction.show(tabId);
   browser.pageAction.setIcon({
     tabId: tabId,

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -34,6 +34,7 @@ subprocess.Popen = popen_no_output
 
 from geckordp.actors.addon.addons import AddonsActor
 from geckordp.actors.descriptors.tab import TabActor
+from geckordp.actors.descriptors.web_extension import WebExtensionActor
 from geckordp.actors.root import RootActor
 from geckordp.actors.web_console import WebConsoleActor
 from geckordp.actors.events import Events
@@ -115,6 +116,52 @@ class Browser:
         else:
             logging.info("Addon already installed")
             return addons[0].get("id")
+
+    def attach_extension_console(self, addon_match="webcat"):
+        # Subscribe to console-message resources from the extension's targets
+        addons = self.root.list_addons()
+        addon = next(
+            (a for a in addons
+             if addon_match in (a.get("id") or "")
+             or addon_match in (a.get("name") or "").lower()
+             or addon_match in (a.get("url") or "")),
+            None,
+        )
+        if addon is None:
+            raise RuntimeError(f"no addon matching {addon_match!r} in {addons!r}")
+        watcher_resp = self.client.send_receive({"to": addon["actor"], "type": "getWatcher"})
+        watcher_actor = watcher_resp.get("actor")
+        if not watcher_actor:
+            raise RuntimeError(f"no watcher actor in {watcher_resp!r}")
+
+        self._ext_logs = []
+        attached_targets = set()
+        def on_resources(data):
+            for entry in data.get("array", []):
+                if len(entry) >= 2 and entry[0] == "console-message":
+                    self._ext_logs.extend(entry[1])
+        def on_target(data):
+            tg = data.get("target", {})
+            actor = tg.get("actor")
+            if actor and actor not in attached_targets:
+                attached_targets.add(actor)
+                self.client.add_event_listener(
+                    actor, Events.Watcher.RESOURCES_AVAILABLE_ARRAY, on_resources
+                )
+        self.client.add_event_listener(
+            watcher_actor, Events.Watcher.TARGET_AVAILABLE_FORM, on_target
+        )
+        self.client.send_receive({
+            "to": watcher_actor, "type": "watchTargets", "targetType": "frame",
+        })
+        self.client.send_receive({
+            "to": watcher_actor, "type": "watchResources",
+            "resourceTypes": ["console-message", "error-message"],
+        })
+        self._ext_watcher_actor = watcher_actor
+
+    def extension_logs(self):
+        return list(getattr(self, "_ext_logs", []))
 
     def navigate(self, url):
         current_tab = self.root.current_tab()

--- a/test/tests.py
+++ b/test/tests.py
@@ -303,6 +303,47 @@ def test_cache_eviction(browser: Browser, server: Server, expected, addon_path, 
     assert expected in res
 
 @pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
+@pytest.mark.parametrize("root, headers, hooks, delegated_fqdn, should_verify", [
+    # site2.localhost shares the same enrollment_hash as site1.localhost
+    pytest.param("cases/testapp",
+        EXPECTED_CSP | {"x-webcat-delegation": "site2.localhost"},
+        FRAMEHOST_HOOK,
+        "site2.localhost", True,
+        id="delegation_accepted_test"),
+
+    # nonenrolled.localhost is not in the enrollment DB, so verifyDelegation rejects.
+    # Page still loads, but no delegation appears in the log.
+    pytest.param("cases/testapp",
+        EXPECTED_CSP | {"x-webcat-delegation": "nonenrolled.localhost"},
+        FRAMEHOST_HOOK,
+        "nonenrolled.localhost", False,
+        id="delegation_rejected_test"),
+], indirect=["root"])
+def test_delegation(browser: Browser, server: Server, delegated_fqdn, should_verify, addon_path, dnsnames):
+    browser.install_extension(addon_path)
+    sleep(7)
+    # Subscribe before navigation so we don't miss the "Setting ok icon" line
+    browser.attach_extension_console()
+    browser.navigate(f"{server.url(dnsnames[0])}/")
+    sleep(3)
+
+    # Page loads successfully in both cases
+    assert "Hello!" in browser.execute("document.body.innerText")
+
+    logs_blob = json.dumps(browser.extension_logs())
+    accepted_marker = f"Setting ok icon (delegation: {delegated_fqdn})"
+    if should_verify:
+        assert accepted_marker in logs_blob, (
+            f"expected delegation marker {accepted_marker!r} in extension logs, got: {logs_blob}"
+        )
+    else:
+        assert accepted_marker not in logs_blob, (
+            f"delegation to non-enrolled {delegated_fqdn!r} should not have been accepted: {logs_blob}"
+        )
+        # And the unadorned ok-icon log should still be present.
+        assert "Setting ok icon" in logs_blob, logs_blob
+
+@pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
 @pytest.mark.parametrize("root, headers, hooks, expected", [
     pytest.param("cases/testapp", EXPECTED_CSP, {}, "Hello v2!",
         id="version_refresh_test"),


### PR DESCRIPTION
This adds a test according to https://github.com/freedomofpress/webcat/issues/172. The logic seemed fine already, with just a little bit of cleanup. Since for now the only effect is in the UI tooltip, the workaround for testing is to add a log line int he extension when that happens and monitor for events there. As a side consequence, this PRs bring the ability to monitor the extension own console, which I think could be useful for other tests as well.