### PR TITLE
Fix cache handling

### DIFF
--- a/extension/src/mocks/validators.mock.ts
+++ b/extension/src/mocks/validators.mock.ts
@@ -1,19 +1,33 @@
 export * from "../webcat/validators";
 
-export const validateProtocolAndPort = (_url: URL) => {
+export const validateProtocolAndPort = (urlobj: URL) => {
   console.log(
-    "[TESTING] validateProtocolAndPort hooked - always returning true for:",
-    _url.href,
+    "[TESTING] validateProtocolAndPort hooked - using ports 8080 and 8443 for:",
+    urlobj.href,
   );
-  return true;
+  if (
+    (urlobj.port === "8080" && urlobj.protocol === "http:") ||
+    (urlobj.port === "8443" && urlobj.protocol === "https:")
+  ) {
+    return true;
+  } else {
+    return false;
+  }
 };
 
-export const enforceHTTPS = (_url: URL) => {
+export function enforceHTTPS(urlobj: URL): string | undefined {
   console.log(
-    "[TESTING] enforceHTTPS hooked - skipping HTTPS enforcement for:",
-    _url.href,
+    "[TESTING] enforceHTTPS hooked - using port 8443 for:",
+    urlobj.href,
   );
-  return undefined;
-};
+  if (
+    urlobj.protocol !== "https:" &&
+    urlobj.hostname.substring(urlobj.hostname.lastIndexOf(".")) !== ".onion"
+  ) {
+    urlobj.protocol = "https:";
+    urlobj.port = "8443";
+    return urlobj.toString();
+  }
+}
 
 console.log("[TESTING] Mock validators module loaded");

--- a/extension/src/webcat/interfaces/originstate.ts
+++ b/extension/src/webcat/interfaces/originstate.ts
@@ -21,6 +21,8 @@ import {
 } from "./bundle";
 import { WebcatError, WebcatErrorCode } from "./errors";
 
+declare const __IS_TESTING__: boolean;
+
 type BundleFetch = {
   promise: Promise<Response>;
   error?: WebcatError;
@@ -123,7 +125,7 @@ export abstract class OriginStateBase {
   public readonly enrollment_hash: Uint8Array;
   public fetcher: BundleFetcher;
   public bundle?: Bundle;
-  public sw_cleanup?: Promise<void>;
+  public sw_cleanup?: Promise<void[]>;
   public references: number;
   public readonly enrollment?: Enrollment;
   public readonly manifest?: Manifest;
@@ -149,10 +151,21 @@ export abstract class OriginStateBase {
 
     // Cleanup service workers, see https://github.com/freedomofpress/webcat/issues/18
     // and upcoming MPI/CISPA paper
-    this.sw_cleanup = browser.browsingData.remove(
-      { hostnames: [fqdn] },
-      { serviceWorkers: true, cache: true },
-    );
+    this.sw_cleanup = Promise.all([
+      // Service Workers and caches need to be cleared separately because the
+      // hostnames option is interpreted differently in the two cases. See
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1797376
+      browser.browsingData.remove(
+        { hostnames: [fqdn] },
+        { serviceWorkers: true },
+      ),
+      browser.browsingData.remove(
+        {
+          hostnames: __IS_TESTING__ ? [`${fqdn}:8080`, `${fqdn}:8443`] : [fqdn],
+        },
+        { cache: true },
+      ),
+    ]);
   }
 }
 

--- a/extension/src/webcat/interfaces/originstate.ts
+++ b/extension/src/webcat/interfaces/originstate.ts
@@ -125,7 +125,6 @@ export abstract class OriginStateBase {
   public readonly enrollment_hash: Uint8Array;
   public fetcher: BundleFetcher;
   public bundle?: Bundle;
-  public sw_cleanup?: Promise<void[]>;
   public references: number;
   public readonly enrollment?: Enrollment;
   public readonly manifest?: Manifest;
@@ -150,24 +149,6 @@ export abstract class OriginStateBase {
     this.enrollment_hash = enrollment_hash;
     this.delegation = delegation;
     this.references = 1;
-
-    // Cleanup service workers, see https://github.com/freedomofpress/webcat/issues/18
-    // and upcoming MPI/CISPA paper
-    this.sw_cleanup = Promise.all([
-      // Service Workers and caches need to be cleared separately because the
-      // hostnames option is interpreted differently in the two cases. See
-      // https://bugzilla.mozilla.org/show_bug.cgi?id=1797376
-      browser.browsingData.remove(
-        { hostnames: [fqdn] },
-        { serviceWorkers: true },
-      ),
-      browser.browsingData.remove(
-        {
-          hostnames: __IS_TESTING__ ? [`${fqdn}:8080`, `${fqdn}:8443`] : [fqdn],
-        },
-        { cache: true },
-      ),
-    ]);
   }
 }
 
@@ -422,8 +403,6 @@ export class OriginStateVerifiedEnrollment extends OriginStateBase {
         );
       }
     }
-    // This is a good moment to enforce this: no response will be forwarded before
-    await this.sw_cleanup;
     const next = new OriginStateVerifiedManifest(this, manifest, valid_sources);
     return next;
   }

--- a/extension/src/webcat/listeners.ts
+++ b/extension/src/webcat/listeners.ts
@@ -437,7 +437,7 @@ export async function installEnrolledListeners(
     ids: registeredFqdns.filter((fqdn) => !fqdns.includes(fqdn)),
   });
 
-  clearBrowserCaches(newFqdns);
+  await clearBrowserCaches(newFqdns);
 
   console.log(
     `[webcat] installEnrolledListeners: registered listeners for ${fqdns.length} FQDN(s)`,

--- a/extension/src/webcat/listeners.ts
+++ b/extension/src/webcat/listeners.ts
@@ -19,7 +19,12 @@ import {
 } from "./response";
 import { errorpage } from "./ui";
 import { retryUpdateIfFailed } from "./update";
-import { getFQDN, isExtensionRequest, isNewerSemver } from "./utils";
+import {
+  clearBrowserCaches,
+  getFQDN,
+  isExtensionRequest,
+  isNewerSemver,
+} from "./utils";
 
 function commitVerifiedOrigin(fqdn: string, holder: OriginStateHolder): void {
   if (holder.stale) {
@@ -214,7 +219,7 @@ export async function beforeHeadersListener(
         case "sharedworker":
         case "audioworklet":
         case "paintworklet":
-          await hookResponseContent(details);
+          hookResponseContent(details);
       }
       break;
     }
@@ -408,33 +413,31 @@ export async function installEnrolledListeners(
   };
   removeListeners(previous);
 
-  // See https://github.com/freedomofpress/webcat/issues/137
-  browser.webRequest.handlerBehaviorChanged();
-
   // Look up existing content scripts and add the ones that are missing
-  const scriptIds = (await browser.scripting.getRegisteredContentScripts()).map(
-    (script) => script.id,
-  );
+  const registeredFqdns = (
+    await browser.scripting.getRegisteredContentScripts()
+  ).map((script) => script.id);
+  const newFqdns = fqdns.filter((fqdn) => {
+    return !registeredFqdns.includes(fqdn);
+  });
   await browser.scripting.registerContentScripts(
-    fqdns
-      .filter((fqdn) => {
-        return !scriptIds.includes(fqdn);
-      })
-      .map((fqdn) => {
-        return {
-          id: fqdn,
-          js: ["dist/hooks/content.js"],
-          matches: buildUrlPatterns([fqdn]),
-          matchOriginAsFallback: true,
-          allFrames: true,
-          runAt: "document_start",
-        };
-      }),
+    newFqdns.map((fqdn) => {
+      return {
+        id: fqdn,
+        js: ["dist/hooks/content.js"],
+        matches: buildUrlPatterns([fqdn]),
+        matchOriginAsFallback: true,
+        allFrames: true,
+        runAt: "document_start",
+      };
+    }),
   );
   // Remove the content scripts whose fqdn is no longer enrolled
   await browser.scripting.unregisterContentScripts({
-    ids: scriptIds.filter((id) => !fqdns.includes(id)),
+    ids: registeredFqdns.filter((fqdn) => !fqdns.includes(fqdn)),
   });
+
+  clearBrowserCaches(newFqdns);
 
   console.log(
     `[webcat] installEnrolledListeners: registered listeners for ${fqdns.length} FQDN(s)`,

--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -19,7 +19,13 @@ import {
 import { logger } from "./logger";
 import { NON_FRAME_TYPES, PASS_THROUGH_TYPES } from "./resources";
 import { errorpage, setOKIcon } from "./ui";
-import { arraysEqual, getFQDN, isNewerSemver, SHA256 } from "./utils";
+import {
+  arraysEqual,
+  clearBrowserCaches,
+  getFQDN,
+  isNewerSemver,
+  SHA256,
+} from "./utils";
 import { extractAndValidateHeaders } from "./validators";
 
 export async function validateResponseHeaders(
@@ -143,7 +149,8 @@ export async function validateResponseHeaders(
     // it via commitVerifiedOrigin later
     originStateHolder.stale = true;
     pendingOrigins.delete(details.requestId);
-    browser.tabs.reload(details.tabId, { bypassCache: true });
+    await clearBrowserCaches([fqdn]);
+    browser.tabs.reload(details.tabId);
   }
 
   const pathname = new URL(details.url).pathname;

--- a/extension/src/webcat/ui.ts
+++ b/extension/src/webcat/ui.ts
@@ -2,6 +2,8 @@ import { WebcatError } from "./interfaces/errors";
 import { logger } from "./logger";
 import { getFQDN } from "./utils";
 
+declare const __IS_TESTING__: boolean;
+
 export function isDarkTheme(): boolean {
   return window.matchMedia("(prefers-color-scheme: dark)").matches;
 }
@@ -115,6 +117,12 @@ export async function errorpage(
   await Promise.all(tabUpdates);
 
   // See https://github.com/freedomofpress/webcat/issues/137
-  await browser.browsingData.remove({ hostnames: [fqdn] }, { cache: true });
+  // and https://bugzilla.mozilla.org/show_bug.cgi?id=1797376
+  await browser.browsingData.remove(
+    {
+      hostnames: __IS_TESTING__ ? [`${fqdn}:8080`, `${fqdn}:8443`] : [fqdn],
+    },
+    { cache: true },
+  );
   await browser.webRequest.handlerBehaviorChanged();
 }

--- a/extension/src/webcat/ui.ts
+++ b/extension/src/webcat/ui.ts
@@ -1,8 +1,6 @@
 import { WebcatError } from "./interfaces/errors";
 import { logger } from "./logger";
-import { getFQDN } from "./utils";
-
-declare const __IS_TESTING__: boolean;
+import { clearBrowserCaches, getFQDN } from "./utils";
 
 export function isDarkTheme(): boolean {
   return window.matchMedia("(prefers-color-scheme: dark)").matches;
@@ -123,13 +121,5 @@ export async function errorpage(
   );
   await Promise.all(tabUpdates);
 
-  // See https://github.com/freedomofpress/webcat/issues/137
-  // and https://bugzilla.mozilla.org/show_bug.cgi?id=1797376
-  await browser.browsingData.remove(
-    {
-      hostnames: __IS_TESTING__ ? [`${fqdn}:8080`, `${fqdn}:8443`] : [fqdn],
-    },
-    { cache: true },
-  );
-  await browser.webRequest.handlerBehaviorChanged();
+  await clearBrowserCaches([fqdn]);
 }

--- a/extension/src/webcat/update.ts
+++ b/extension/src/webcat/update.ts
@@ -18,6 +18,8 @@ import { hexToUint8Array, Uint8ArrayToBase64 } from "./encoding";
 import { installEnrolledListeners } from "./listeners";
 import { arraysEqual } from "./utils";
 
+declare const __IS_TESTING__: boolean;
+
 let lastUpdateFailed = false;
 
 const ALARM_NAME = "webcat-scheduled-update";
@@ -60,7 +62,8 @@ export async function handleUpdateAlarm(
     const lastUpdated = await db.getLastUpdated();
     if (
       lastUpdated === null ||
-      Date.now() - lastUpdated >= UPDATE_INTERVAL_MS
+      Date.now() - lastUpdated >= UPDATE_INTERVAL_MS ||
+      __IS_TESTING__
     ) {
       console.log("[webcat] Running scheduled update (alarm check)");
       try {
@@ -136,6 +139,20 @@ export async function update(
     // 2 Await latest block
     const block = await (await blockResponse).json();
     console.log("[webcat] Update block fetched");
+
+    if (__IS_TESTING__) {
+      const reschedule = block.__WEBCAT_TEST_SCHEDULE_UPDATE__;
+      if (reschedule) {
+        console.log(
+          "[webcat] Rescheduling update for test in",
+          reschedule,
+          "second(s)",
+        );
+        browser.alarms.create(ALARM_NAME, {
+          when: Date.now() + reschedule * 1000,
+        });
+      }
+    }
 
     // 3 Verify block against validatorSet
     const { proto: vset, cryptoIndex } = await importValidators(

--- a/extension/src/webcat/utils.ts
+++ b/extension/src/webcat/utils.ts
@@ -1,3 +1,5 @@
+declare const __IS_TESTING__: boolean;
+
 export function getFQDN(url: string): string {
   const urlobj = new URL(url);
   return urlobj.hostname;
@@ -61,4 +63,21 @@ export function isNewerSemver(a: string, b: string): boolean {
   }
 
   return false;
+}
+
+export async function clearBrowserCaches(fqdns: string[]) {
+  // Caching is complicated. See:
+  //  - https://github.com/freedomofpress/webcat/issues/18
+  //  - https://dl.acm.org/doi/10.1145/3774904.3792624
+  //  - https://github.com/freedomofpress/webcat/issues/137
+  //  - https://bugzilla.mozilla.org/show_bug.cgi?id=1797376
+  await browser.browsingData.remove(
+    { hostnames: fqdns },
+    { serviceWorkers: true },
+  );
+  await browser.browsingData.remove({}, { cache: true });
+  // TODO: This call fails silently if invoked more than 20 times
+  // in 10 minutes. Figure out a way to deal with it safely. See
+  // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/handlerBehaviorChanged
+  await browser.webRequest.handlerBehaviorChanged();
 }

--- a/extension/src/webcat/utils.ts
+++ b/extension/src/webcat/utils.ts
@@ -71,6 +71,9 @@ export async function clearBrowserCaches(fqdns: string[]) {
   //  - https://dl.acm.org/doi/10.1145/3774904.3792624
   //  - https://github.com/freedomofpress/webcat/issues/137
   //  - https://bugzilla.mozilla.org/show_bug.cgi?id=1797376
+  if (fqdns.length === 0) {
+    return;
+  }
   await browser.browsingData.remove(
     { hostnames: fqdns },
     { serviceWorkers: true },

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -11,6 +11,6 @@
     "resolveJsonModule": true,
     "outDir": "./dist"
   },
-  "include": ["./src/*.ts", "./types/*.d.ts"],
+  "include": ["./src/**/*.ts", "./types/**/*.d.ts"],
   "exclude": ["node_modules", "src/webcat/hooks"]
 }

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -99,11 +99,12 @@ def ssl_cert(dnsnames, non_enrolled_dnsnames):
     cert_path, key_path = generate_ssl_cert(tmpdir, dnsnames + non_enrolled_dnsnames)
     return cert_path, key_path
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def update_server():
     us = UpdateServer()
     us.start()
-    return us
+    yield us
+    us.stop()
 
 @pytest.fixture(scope="session")
 def bundle_generator():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -30,6 +30,7 @@ _tbb_safer_skips = {
     "corrupted_wasm_frame_test": "WebAssembly not available at this security level",
 }
 _tbb_safest_skips = {
+    "in_frame": "JavaScript fully disabled at this security level",
     "no_wasm_test": "JavaScript fully disabled at this security level",
     "corrupted_js_test": "JavaScript fully disabled at this security level",
     "corrupted_worker_test": "JavaScript fully disabled at this security level",

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -292,6 +292,7 @@ class Server:
 
     def stop(self):
         self.httpd.shutdown()
+        self.httpd.server_close()
         self.thread.join()
 
     def url(self, hostname="127.0.0.1"):
@@ -358,7 +359,7 @@ class UpdateServer:
                     self.send_response(200)
                     self.send_header("Content-Type", "application/json")
                     self.end_headers()
-                    self.wfile.write(json.dumps({
+                    block = {
                         "signed_header": {
                             "header": {
                                 "height": "0",
@@ -400,7 +401,12 @@ class UpdateServer:
                                 ],
                             },
                         },
-                    }).encode())
+                    }
+                    if us.reschedule_in:
+                        block["__WEBCAT_TEST_SCHEDULE_UPDATE__"] = us.reschedule_in
+                        if us.reschedule_once:
+                            us.reschedule_in = None
+                    self.wfile.write(json.dumps(block).encode())
                 else:
                     self.send_response(404)
                     self.end_headers()
@@ -416,7 +422,12 @@ class UpdateServer:
 
     def stop(us):
         us.httpd.shutdown()
+        us.httpd.server_close()
         us.thread.join()
 
     def set(us, host, hash):
         us.hosts[host] = hash
+
+    def reschedule(us, time_in_seconds: float, once=False):
+        us.reschedule_in = time_in_seconds
+        us.reschedule_once = once

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -330,12 +330,12 @@ class Server:
                     if type(hook) is bytes:
                         self.send_response(200)
                         self.send_header("Content-Type", "text/plain")
-                        self.end_headers()
+                        self.end_headers(hook)
                         self.wfile.write(hook)
                     else:
                         self.send_response(hook.status)
                         self.send_header("Content-Type", hook.type)
-                        self.end_headers(hook.headers)
+                        self.end_headers(hook.data, hook.headers)
                         self.wfile.write(hook.data)
                         sleep(hook.delay)
 
@@ -346,8 +346,9 @@ class Server:
                     counts[path] = counts.get(path, 0) + 1
                     served.notify_all()
 
-            def end_headers(self, override={}):
-                h = headers.copy()
+            def end_headers(self, data=None, override={}):
+                h = {} if data is None else {"Content-Length": f"{len(data)}"}
+                h.update(headers)
                 h.update(override)
                 for k, v in h.items(): self.send_header(k, v)
                 super().end_headers()

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -276,7 +276,7 @@ class TorBrowser(Browser):
 
 class Hook:
     type = "text/plain"
-    delay = 0
+    delay = None
     headers = {}
     status = 200
     def __init__(self, data, type=None, base64=False, delay=None, headers={}, status=None):
@@ -335,9 +335,8 @@ class Server:
                     else:
                         self.send_response(hook.status)
                         self.send_header("Content-Type", hook.type)
-                        self.end_headers(hook.data, hook.headers)
+                        self.end_headers(hook.data, hook.headers, hook.delay)
                         self.wfile.write(hook.data)
-                        sleep(hook.delay)
 
                 else:
                     super().do_GET()
@@ -346,11 +345,13 @@ class Server:
                     counts[path] = counts.get(path, 0) + 1
                     served.notify_all()
 
-            def end_headers(self, data=None, override={}):
+            def end_headers(self, data=None, override={}, delay=None):
                 h = {} if data is None else {"Content-Length": f"{len(data)}"}
                 h.update(headers)
                 h.update(override)
                 for k, v in h.items(): self.send_header(k, v)
+                if delay is not None:
+                    sleep(delay)
                 super().end_headers()
 
             def log_message(self, *a): pass  # suppress logs

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -240,6 +240,9 @@ class Server:
     class MultiThreadedServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
         pass
 
+    _served = threading.Condition()
+    _counts: dict[str,int] = {}
+
     def __init__(self, root=".", headers=None, hooks=None, ssl_cert=None, ssl_key=None):
         self.root = os.path.abspath(root)
         self.headers = headers or {}
@@ -249,7 +252,7 @@ class Server:
         self.port = None
 
     def start(self):
-        root, headers, hooks = self.root, self.headers, self.hooks
+        root, headers, hooks, served, counts = self.root, self.headers, self.hooks, self._served, self._counts
 
         class Handler(http.server.SimpleHTTPRequestHandler):
             def translate_path(self, path):
@@ -272,6 +275,10 @@ class Server:
 
                 else:
                     super().do_GET()
+                
+                with served:
+                    counts[path] = counts.get(path, 0) + 1
+                    served.notify_all()
 
             def end_headers(self, override={}):
                 h = headers.copy()
@@ -298,6 +305,21 @@ class Server:
     def url(self, hostname="127.0.0.1"):
         scheme = "https" if self.ssl_cert else "http"
         return f"{scheme}://{hostname}:{self.port}"
+    
+    def wait_for(self, paths):
+        with self._served:
+            counts = {}
+            for path in paths:
+                counts[path] = self._counts.get(path, 0)
+            while True:
+                if not self._served.wait(15):
+                    raise RuntimeError(f"timeout waiting for '{"', '".join(counts.keys())}'")
+                for path, count in list(counts.items()):
+                    if self._counts.get(path, 0) > count:
+                        del counts[path]
+                if len(counts) == 0:
+                    break
+        sleep(0.2) # minimal sleep to allow the browser to process the last response
 
 def generate_ssl_cert(output_dir, dnsnames=[]):
     """Generate a self-signed certificate for 127.0.0.1."""
@@ -331,6 +353,10 @@ def generate_ssl_cert(output_dir, dnsnames=[]):
 class UpdateServer:
     hosts = {}
 
+    _reschedule_in = None
+    _reschedule_once = False
+    _update_served = threading.Condition()
+
     @staticmethod
     def canonicalize(host: str):
         parts = host.split(".")
@@ -355,6 +381,8 @@ class UpdateServer:
                         }
                     }
                     self.wfile.write(json.dumps(list).encode())
+                    with us._update_served:
+                        us._update_served.notify_all()
                 elif self.path == "/block.json":
                     self.send_response(200)
                     self.send_header("Content-Type", "application/json")
@@ -402,10 +430,10 @@ class UpdateServer:
                             },
                         },
                     }
-                    if us.reschedule_in:
-                        block["__WEBCAT_TEST_SCHEDULE_UPDATE__"] = us.reschedule_in
-                        if us.reschedule_once:
-                            us.reschedule_in = None
+                    if us._reschedule_in:
+                        block["__WEBCAT_TEST_SCHEDULE_UPDATE__"] = us._reschedule_in
+                        if us._reschedule_once:
+                            us._reschedule_in = None
                     self.wfile.write(json.dumps(block).encode())
                 else:
                     self.send_response(404)
@@ -429,5 +457,9 @@ class UpdateServer:
         us.hosts[host] = hash
 
     def reschedule(us, time_in_seconds: float, once=False):
-        us.reschedule_in = time_in_seconds
-        us.reschedule_once = once
+        us._reschedule_in = time_in_seconds
+        us._reschedule_once = once
+
+    def wait_for_update(us):
+        with us._update_served:
+            us._update_served.wait()

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -278,12 +278,14 @@ class Hook:
     type = "text/plain"
     delay = 0
     headers = {}
-    def __init__(self, data, type=None, base64=False, delay=None, headers={}):
+    status = 200
+    def __init__(self, data, type=None, base64=False, delay=None, headers={}, status=None):
         if isinstance(data, Hook):
             self.data = data.data
             self.type = data.type
             self.delay = data.delay
             self.headers = data.headers
+            self.status = data.status
         elif base64:
             self.data = b64decode(data)
         else:
@@ -292,6 +294,8 @@ class Hook:
             self.type = type
         if delay is not None:
             self.delay = delay
+        if status is not None:
+            self.status = status
         self.headers = self.headers | headers
 
 class Server:
@@ -322,13 +326,14 @@ class Server:
             def do_GET(self):
                 path = self.path.split("?", 1)[0]
                 if path in hooks:
-                    self.send_response(200)
                     hook = hooks[path]
                     if type(hook) is bytes:
+                        self.send_response(200)
                         self.send_header("Content-Type", "text/plain")
                         self.end_headers()
                         self.wfile.write(hook)
                     else:
+                        self.send_response(hook.status)
                         self.send_header("Content-Type", hook.type)
                         self.end_headers(hook.headers)
                         self.wfile.write(hook.data)
@@ -366,20 +371,43 @@ class Server:
         scheme = "https" if self.ssl_cert else "http"
         return f"{scheme}://{hostname}:{self.port}"
     
+    class _Wait:
+        def __init__(self, server, paths):
+            self.server = server
+            self.paths = paths
+            self.timeout = False
+
+        def __enter__(self):
+            lock = threading.Lock()
+            lock.acquire()
+            self.thread = threading.Thread(target=self._wait, args=(lock,))
+            self.thread.start()
+            lock.acquire()
+
+        def __exit__(self, exc_type, exc, tb):
+            self.thread.join()
+            if self.timeout:
+                raise RuntimeError(f"timeout waiting for '{"', '".join(self.counts.keys())}'")
+            sleep(0.2) # minimal sleep to allow the browser to process the last response
+
+        def _wait(self, lock):
+            with self.server._served:
+                lock.release()
+                self.counts = {}
+                for path in self.paths:
+                    self.counts[path] = self.server._counts.get(path, 0)
+                while True:
+                    if not self.server._served.wait(15):
+                        self.timeout = True
+                        break
+                    for path, count in list(self.counts.items()):
+                        if self.server._counts.get(path, 0) > count:
+                            del self.counts[path]
+                    if len(self.counts) == 0:
+                        break
+    
     def wait_for(self, paths):
-        with self._served:
-            counts = {}
-            for path in paths:
-                counts[path] = self._counts.get(path, 0)
-            while True:
-                if not self._served.wait(15):
-                    raise RuntimeError(f"timeout waiting for '{"', '".join(counts.keys())}'")
-                for path, count in list(counts.items()):
-                    if self._counts.get(path, 0) > count:
-                        del counts[path]
-                if len(counts) == 0:
-                    break
-        sleep(0.2) # minimal sleep to allow the browser to process the last response
+        return Server._Wait(self, paths)
 
 def generate_ssl_cert(output_dir, dnsnames=[]):
     """Generate a self-signed certificate for 127.0.0.1."""

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -411,17 +411,17 @@ def generate_ssl_cert(output_dir, dnsnames=[]):
     return cert_path, key_path
 
 class UpdateServer:
-    hosts = {}
-
-    _reschedule_in = None
-    _reschedule_once = False
-    _update_served = threading.Condition()
-
     @staticmethod
     def canonicalize(host: str):
         parts = host.split(".")
         parts.reverse()
         return f"canonical/.{".".join(parts)}"
+    
+    def __init__(us): 
+        us._reschedule_in = None
+        us._reschedule_once = False
+        us._update_served = threading.Condition()
+        us._hosts = {}
 
     def start(us):
         class Handler(http.server.SimpleHTTPRequestHandler):
@@ -431,7 +431,7 @@ class UpdateServer:
                     self.send_header("Content-Type", "application/json")
                     self.end_headers()
                     leaves = []
-                    for host, hash in us.hosts.items():
+                    for host, hash in us._hosts.items():
                         leaves.append([UpdateServer.canonicalize(host), f"0A{len(hash):x}{hash}"])
                     list = {
                         "leaves": leaves,
@@ -514,7 +514,7 @@ class UpdateServer:
         us.thread.join()
 
     def set(us, host, hash):
-        us.hosts[host] = hash
+        us._hosts[host] = hash
 
     def reschedule(us, time_in_seconds: float, once=False):
         us._reschedule_in = time_in_seconds

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -275,13 +275,24 @@ class TorBrowser(Browser):
                 json.dump(prefs, file)
 
 class Hook:
-    def __init__(self, data, type="text/plain", base64=False, delay=0, headers={}):
-        self.delay, self.headers = delay, headers
-        if base64:
+    type = "text/plain"
+    delay = 0
+    headers = {}
+    def __init__(self, data, type=None, base64=False, delay=None, headers={}):
+        if isinstance(data, Hook):
+            self.data = data.data
+            self.type = data.type
+            self.delay = data.delay
+            self.headers = data.headers
+        elif base64:
             self.data = b64decode(data)
         else:
             self.data = data
-        self.type = type
+        if type is not None:
+            self.type = type
+        if delay is not None:
+            self.delay = delay
+        self.headers = self.headers | headers
 
 class Server:
     class MultiThreadedServer(socketserver.ThreadingMixIn, socketserver.TCPServer):

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -238,7 +238,7 @@ class Hook:
 
 class Server:
     class MultiThreadedServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
-        pass
+        allow_reuse_address = True
 
     _served = threading.Condition()
     _counts: dict[str,int] = {}
@@ -249,7 +249,10 @@ class Server:
         self.hooks = hooks or {}
         self.ssl_cert = ssl_cert
         self.ssl_key = ssl_key
-        self.port = None
+        if self.ssl_cert and self.ssl_key:
+            self.port = 8443
+        else:
+            self.port = 8080
 
     def start(self):
         root, headers, hooks, served, counts = self.root, self.headers, self.hooks, self._served, self._counts
@@ -288,12 +291,11 @@ class Server:
 
             def log_message(self, *a): pass  # suppress logs
 
-        self.httpd = Server.MultiThreadedServer(("127.0.0.1", 0), Handler)
+        self.httpd = Server.MultiThreadedServer(("127.0.0.1", self.port), Handler)
         if self.ssl_cert and self.ssl_key:
             context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
             context.load_cert_chain(self.ssl_cert, self.ssl_key)
             self.httpd.socket = context.wrap_socket(self.httpd.socket, server_side=True)
-        self.port = self.httpd.server_address[1]
         self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
         self.thread.start()
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -234,13 +234,13 @@ def test_webcat(browser, in_frame, server: Server, update_server: UpdateServer, 
         "cache-control": "max-age=180"
     }, {"/console_log.png": WEBCAT_ICON}, "ERR_WEBCAT_FILE_MISMATCH"),
 ], indirect=["root"])
-def test_in_memory_cache(browser, server, update_server: UpdateServer, expected, addon_path):
+def test_in_memory_cache(browser, server: Server, update_server: UpdateServer, expected, addon_path):
     browser.navigate(f'{server.url()}/console_log.png')
-    sleep(2)
+    server.wait_for({"/favicon.ico"})
     browser.install_extension(addon_path)
     update_server.wait_for_update()
     browser.navigate(f'{server.url()}/console_log.png')
-    sleep(2)
+    sleep(2) # loading from cache, so can't use server.wait_for
     res = browser.execute("document.body.innerText")
     assert expected in res
 
@@ -260,7 +260,7 @@ def test_multiple_tabs(browser: Browser, server: Server, update_server: UpdateSe
         f"window.open('{server.url()}');"
         f"setTimeout(() => location.href = '{server.url()}/x', 1000)"
     )
-    sleep(3)
+    server.wait_for({"/js/alert.js"})
     res = browser.execute("document.body.innerText")
     assert expected in res
 
@@ -287,7 +287,7 @@ def test_non_enrolled_subresource(browser: Browser, server: Server, update_serve
     browser.install_extension(addon_path)
     update_server.wait_for_update()
     browser.navigate(non_enrolled_url)
-    sleep(5)
+    server.wait_for({"/js/alert.js"})
     res = browser.execute("document.body.innerText")
     assert expected in res
 
@@ -310,11 +310,16 @@ def test_cache_eviction(browser: Browser, server: Server, update_server: UpdateS
         f"    location.href = '{server.url(dnsnames[1])}/console_log.png';"
          "}, 1000)"
     )
-    sleep(3)
+    server.wait_for({"/js/alert.js"})
     res = browser.execute("document.body.innerText")
     assert expected in res
 
-@pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
+@pytest.mark.parametrize("browser, paths_to_wait", [
+    pytest.param("firefox", NON_FRAME_PATHS, id="firefox"),
+    pytest.param("tbb", NON_FRAME_PATHS-{"/workers/serviceworker.js"}, id="tbb"),
+    pytest.param("tbb_safer", NON_FRAME_PATHS-{"/workers/serviceworker.js"}-WASM_PATHS, id="tbb_safer"),
+    pytest.param("tbb_safest", NON_FRAME_PATHS-JS_PATHS-WORKER_PATHS-WASM_PATHS, id="tbb_safest")
+], indirect=["browser"])
 @pytest.mark.parametrize("root, headers, hooks, delegated_fqdn, should_verify", [
     # site2.localhost shares the same enrollment_hash as site1.localhost
     pytest.param("cases/testapp",
@@ -331,13 +336,13 @@ def test_cache_eviction(browser: Browser, server: Server, update_server: UpdateS
         "nonenrolled.localhost", False,
         id="delegation_rejected_test"),
 ], indirect=["root"])
-def test_delegation(browser: Browser, server: Server, delegated_fqdn, should_verify, addon_path, dnsnames):
+def test_delegation(browser: Browser, server: Server, update_server: UpdateServer, delegated_fqdn, should_verify, paths_to_wait, addon_path, dnsnames):
     browser.install_extension(addon_path)
-    sleep(7)
+    update_server.wait_for_update()
     # Subscribe before navigation so we don't miss the "Setting ok icon" line
     browser.attach_extension_console()
     browser.navigate(f"{server.url(dnsnames[0])}/")
-    sleep(3)
+    server.wait_for(paths_to_wait)
 
     # Page loads successfully in both cases
     assert "Hello!" in browser.execute("document.body.innerText")
@@ -355,17 +360,22 @@ def test_delegation(browser: Browser, server: Server, delegated_fqdn, should_ver
         # And the unadorned ok-icon log should still be present.
         assert "Setting ok icon" in logs_blob, logs_blob
 
-@pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
+@pytest.mark.parametrize("browser, paths_to_wait", [
+    pytest.param("firefox", NON_FRAME_PATHS, id="firefox"),
+    pytest.param("tbb", NON_FRAME_PATHS-{"/workers/serviceworker.js"}, id="tbb"),
+    pytest.param("tbb_safer", NON_FRAME_PATHS-{"/workers/serviceworker.js"}-WASM_PATHS, id="tbb_safer"),
+    pytest.param("tbb_safest", NON_FRAME_PATHS-JS_PATHS-WORKER_PATHS-WASM_PATHS, id="tbb_safest")
+], indirect=["browser"])
 @pytest.mark.parametrize("root, headers, hooks, expected", [
     pytest.param("cases/testapp", EXPECTED_CSP, {}, "Hello v2!",
         id="version_refresh_test"),
 ], indirect=["root"])
-def test_version_refresh(browser: Browser, server: Server, update_server: UpdateServer, bundle_generator, expected, addon_path, root):
+def test_version_refresh(browser: Browser, server: Server, update_server: UpdateServer, bundle_generator, expected, paths_to_wait, addon_path, root):
     # Load v0.1: server serves the bundle that the `root` fixture signed.
     browser.install_extension(addon_path)
     update_server.wait_for_update()
     browser.navigate(server.url())
-    sleep(3)
+    server.wait_for(paths_to_wait)
     assert "Hello!" in browser.execute("document.body.innerText")
 
     # Build a v0.2 bundle signed with the same enrollment as v0.1, with a
@@ -404,5 +414,5 @@ def test_version_refresh(browser: Browser, server: Server, update_server: Update
         headers={"cache-control": "no-store"})
 
     browser.execute("location.reload()")
-    sleep(5)
+    server.wait_for(paths_to_wait)
     assert expected in browser.execute("document.body.innerText")

--- a/test/tests.py
+++ b/test/tests.py
@@ -6,6 +6,8 @@ from time import sleep
 from helpers import Browser, TorBrowser, Server, Hook, UpdateServer
 import logging
 import json
+import canonicaljson
+import hashlib
 from pytest_check import check
 
 logging.getLogger("geckordp").setLevel(logging.CRITICAL)
@@ -423,15 +425,25 @@ def test_version_refresh(browser: Browser, server: Server, update_server: Update
         "cache-control": "max-age=180"
     }, {}, "ERR_WEBCAT_FILE_MISMATCH"),
 ], indirect=["root"])
-def test_in_memory_cache_on_update(browser, server: Server, update_server: UpdateServer, expected, addon_path):
+def test_in_memory_cache_on_update(browser, server: Server, update_server: UpdateServer, expected, addon_path, root, non_enrolled_dnsnames):
     browser.install_extension(addon_path)
     update_server.reschedule(2, once=True)
     update_server.wait_for_update()
-    browser.navigate(f'{server.url()}/console_log.png')
+
+    # load a non-enrolled site into browser cache
+    browser.navigate(f'{server.url(non_enrolled_dnsnames[0])}/console_log.png')
     server.wait_for({"/favicon.ico"})
+
+    # enroll the site
+    with open(f'{root}/.well-known/webcat/bundle.json') as bundle:
+        enrollment = json.load(bundle)["enrollment"]
+        canonical_enrollment = canonicaljson.encode_canonical_json(enrollment)
+        enrollment_hash = hashlib.sha256(canonical_enrollment).hexdigest()
+        update_server.set(non_enrolled_dnsnames[0], enrollment_hash)
+    
     sleep(2) # wait for the rescheduled update
     server.hooks["/console_log.png"] = WEBCAT_ICON
-    browser.navigate(f'{server.url()}/console_log.png')
+    browser.navigate(f'{server.url(non_enrolled_dnsnames[0])}/console_log.png')
     sleep(2)
     res = browser.execute("document.body.innerText")
     assert expected in res

--- a/test/tests.py
+++ b/test/tests.py
@@ -416,3 +416,22 @@ def test_version_refresh(browser: Browser, server: Server, update_server: Update
     browser.execute("location.reload()")
     server.wait_for(paths_to_wait)
     assert expected in browser.execute("document.body.innerText")
+
+@pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
+@pytest.mark.parametrize("root, headers, hooks, expected", [
+    ("cases/testapp", EXPECTED_CSP | {
+        "cache-control": "max-age=180"
+    }, {}, "ERR_WEBCAT_FILE_MISMATCH"),
+], indirect=["root"])
+def test_in_memory_cache_on_update(browser, server: Server, update_server: UpdateServer, expected, addon_path):
+    browser.install_extension(addon_path)
+    update_server.reschedule(2, once=True)
+    update_server.wait_for_update()
+    browser.navigate(f'{server.url()}/console_log.png')
+    server.wait_for({"/favicon.ico"})
+    sleep(2) # wait for the rescheduled update
+    server.hooks["/console_log.png"] = WEBCAT_ICON
+    browser.navigate(f'{server.url()}/console_log.png')
+    sleep(2)
+    res = browser.execute("document.body.innerText")
+    assert expected in res

--- a/test/tests.py
+++ b/test/tests.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 import pytest
 from time import sleep
-from helpers import Browser, Server, Hook
+from helpers import Browser, TorBrowser, Server, Hook, UpdateServer
 import logging
 import json
 from pytest_check import check
@@ -67,6 +67,14 @@ FRAMEHOST_HOOK = {
     }),
 }
 
+CSS_PATHS = set(map(lambda filename: f"/css/{filename}", os.listdir("./cases/testapp/css/")))
+JS_PATHS = set(map(lambda filename: f"/js/{filename}", os.listdir("./cases/testapp/js/")))
+WASM_PATHS = set(map(lambda filename: f"/wasm/{filename}", os.listdir("./cases/testapp/wasm/")))
+WORKER_PATHS = set(map(lambda filename: f"/workers/{filename}", os.listdir("./cases/testapp/workers/")))
+FRAME_PATHS = {"/js/framehost.js", "/wasm/frame_addThree.wasm"}
+ALL_PATHS = {"/"}.union(CSS_PATHS,JS_PATHS,WASM_PATHS,WORKER_PATHS)
+NON_FRAME_PATHS = ALL_PATHS-FRAME_PATHS
+
 def setdiff(a: list, b: list):
     a = a.copy()
     for el in b:
@@ -78,10 +86,10 @@ def setdiff(a: list, b: list):
 
 @pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
 @pytest.mark.parametrize("in_frame", [False, True], ids=["plain","in_frame"])
-@pytest.mark.parametrize("root, headers, hooks, expected, logs, errors, rejections", [
+@pytest.mark.parametrize("root, headers, hooks, expected, logs, errors, rejections, paths_to_wait", [
 
     # Basic correct execution
-    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK, "Hello!", EXPECTED_LOGS, [], [],
+    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK, "Hello!", EXPECTED_LOGS, [], [], NON_FRAME_PATHS,
         id="basic_test"),
 
     # Correct execution without WebAssembly or Workers
@@ -105,95 +113,99 @@ def setdiff(a: list, b: list):
                 LOGENTRY_LOAD_AUDIOWORKLET,
                 LOGENTRY_INLINE,
             ]), [], [],
+        NON_FRAME_PATHS-WASM_PATHS-WORKER_PATHS-{"/js/wasm_frame.js"},
         id="no_wasm_test"),
 
     # Wrong CSP
     pytest.param("cases/testapp", {
             "content-security-policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; "
                                     "style-src 'self'; frame-src 'none'; worker-src 'self';"
-        }, FRAMEHOST_HOOK, "ERR_WEBCAT_CSP_MISMATCH", [], [], [],
+        }, FRAMEHOST_HOOK, "ERR_WEBCAT_CSP_MISMATCH", [], [], [], {"/"},
         id="wrong_csp_test"),
 
     # Missing CSP
     pytest.param("cases/testapp", {
             # No CSP header
-        }, FRAMEHOST_HOOK, "ERR_WEBCAT_HEADERS_MISSING_CRITICAL", [], [], [],
+        }, FRAMEHOST_HOOK, "ERR_WEBCAT_HEADERS_MISSING_CRITICAL", [], [], [], {"/"},
         id="missing_csp_test"),
 
     # Hook / with static content
-    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/": b"<html><body>replaced index</body></html>"}, "ERR_WEBCAT_FILE_MISMATCH", [], [], [],
+    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/": b"<html><body>replaced index</body></html>"}, "ERR_WEBCAT_FILE_MISMATCH", [], [], [], {"/"},
         id="corrupted_index_test"),
 
     # Hook /.well-known/webcat/bundle.json
-    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/.well-known/webcat/bundle.json": b'{"a":"b"}'}, "ERR_WEBCAT_BUNDLE_MISSING_ENROLLMENT", [], [], [],
+    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/.well-known/webcat/bundle.json": b'{"a":"b"}'}, "ERR_WEBCAT_BUNDLE_MISSING_ENROLLMENT", [], [], [], {"/"},
         id="corrupted_manifest_test"),
 
     # Hook /js/alert.js
-    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/js/alert.js": b"alert('hacked');"}, "ERR_WEBCAT_FILE_MISMATCH", [], [], [],
+    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/js/alert.js": b"alert('hacked');"}, "ERR_WEBCAT_FILE_MISMATCH", [], [], [], {"/js/alert.js"},
         id="corrupted_js_test"),
 
     # Hook /wasm/addTwo.wasm
     pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/wasm/addTwo.wasm": BAD_WASM}, "Hello!", setdiff(EXPECTED_LOGS, [LOGENTRY_WASM]), [], [
             ['Error: [WEBCAT] Unauthorized WebAssembly bytecode: HBppdg6328KAR4wUuqq0tuD4b7l5Wrl9ne6AfB4C0G4', '']
-        ],
+        ], NON_FRAME_PATHS,
         id="corrupted_wasm_test"),
 
     # Hook /wasm/addThree.wasm
     pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/wasm/addThree.wasm": BAD_WASM}, "Hello!", setdiff(EXPECTED_LOGS, [LOGENTRY_WASM_FETCH]), [], [
             ['Error: [WEBCAT] Unauthorized WebAssembly bytecode: HBppdg6328KAR4wUuqq0tuD4b7l5Wrl9ne6AfB4C0G4', '']
-        ],
+        ], NON_FRAME_PATHS,
         id="corrupted_wasm_fetch_test"),
 
     # Hook /wasm/reverseSub.wasm
     pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/wasm/reverseSub.wasm": BAD_WASM}, "Hello!", setdiff(EXPECTED_LOGS, [LOGENTRY_LOAD_WASMWORKER]), [
             ['Error: [WEBCAT] Unauthorized WebAssembly bytecode: HBppdg6328KAR4wUuqq0tuD4b7l5Wrl9ne6AfB4C0G4', '/workers/wasm_worker.js']
-        ], [],
+        ], [], NON_FRAME_PATHS-{"/wasm/reverseSub.wasm"},
         id="corrupted_wasm_worker_test"),
 
     # Hook /workers/worker.js
-    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/workers/worker.js": Hook(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], [],
+    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/workers/worker.js": Hook(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], [], {"/workers/worker.js"},
         id="corrupted_worker_test"),
 
     # Hook /workers/sharedworker.js
-    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/workers/sharedworker.js": Hook(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], [],
+    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/workers/sharedworker.js": Hook(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], [], {"/workers/sharedworker.js"},
         id="corrupted_sharedworker_test"),
 
     # Hook /workers/serviceworker.js
-    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/workers/serviceworker.js": Hook(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], [],
+    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/workers/serviceworker.js": Hook(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], [], {"/workers/serviceworker.js"},
         id="corrupted_serviceworker_test"),
 
     # Hook /workers/audioworklet.js
-    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/workers/audioworklet.js": Hook(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], [],
+    pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/workers/audioworklet.js": Hook(b"console.log('hacked');", "text/javascript")}, "ERR_WEBCAT_FILE_MISMATCH", [], [], [], {"/workers/audioworklet.js"},
         id="corrupted_audioworklet_test"),
     
     # Hook /wasm/aw_addTwo.wasm
     pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/wasm/aw_addTwo.wasm": BAD_WASM}, "Hello!", setdiff(EXPECTED_LOGS, [LOGENTRY_LOAD_AUDIOWORKLET]), [
             ['Error: [WEBCAT] Unauthorized WebAssembly bytecode: HBppdg6328KAR4wUuqq0tuD4b7l5Wrl9ne6AfB4C0G4', '/workers/audioworklet.js']
-        ], [],
+        ], [], NON_FRAME_PATHS,
         id="corrupted_wasm_audioworklet_test"),
 
     # Hook /wasm/inline_addTwo.wasm
     pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/wasm/inline_addTwo.wasm": BAD_WASM}, "Hello!", setdiff(EXPECTED_LOGS, [LOGENTRY_INLINE]), [
             ['Error: [WEBCAT] Unauthorized WebAssembly bytecode: HBppdg6328KAR4wUuqq0tuD4b7l5Wrl9ne6AfB4C0G4', '']
-        ], [],
+        ], [], NON_FRAME_PATHS,
         id="corrupted_wasm_inline_test"),
 
     # Hook /wasm/frame_addThree.wasm
     pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/wasm/frame_addThree.wasm": BAD_WASM}, "Hello!", setdiff(EXPECTED_LOGS, [LOGENTRY_WASM_FRAME]), [], [
             ['Error: [WEBCAT] Unauthorized WebAssembly bytecode: HBppdg6328KAR4wUuqq0tuD4b7l5Wrl9ne6AfB4C0G4', '']
-        ],
+        ], NON_FRAME_PATHS,
         id="corrupted_wasm_frame_test"),
 
 ], indirect=["root"])
-def test_webcat(browser, in_frame, server, expected, logs, errors, rejections, addon_path, dnsnames, non_enrolled_dnsnames):
+def test_webcat(browser, in_frame, server: Server, update_server: UpdateServer, expected, logs, errors, rejections, paths_to_wait, addon_path, dnsnames, non_enrolled_dnsnames):
     logs, errors, rejections = logs.copy(), errors.copy(), rejections.copy()
     browser.install_extension(addon_path)
-    sleep(7)
+    update_server.wait_for_update()
     if in_frame:
         browser.navigate(f"{server.url(non_enrolled_dnsnames[0])}/framehost.html?url={server.url(dnsnames[0])}")
     else:
         browser.navigate(server.url())
-    sleep(3)
+    if isinstance(browser, TorBrowser):
+        server.wait_for(paths_to_wait-{"/workers/serviceworker.js"})
+    else:      
+        server.wait_for(paths_to_wait)
     if not in_frame:
         res = browser.execute("document.body.innerText")
         assert expected in res
@@ -222,11 +234,11 @@ def test_webcat(browser, in_frame, server, expected, logs, errors, rejections, a
         "cache-control": "max-age=180"
     }, {"/console_log.png": WEBCAT_ICON}, "ERR_WEBCAT_FILE_MISMATCH"),
 ], indirect=["root"])
-def test_in_memory_cache(browser, server, expected, addon_path):
+def test_in_memory_cache(browser, server, update_server: UpdateServer, expected, addon_path):
     browser.navigate(f'{server.url()}/console_log.png')
     sleep(2)
     browser.install_extension(addon_path)
-    sleep(7)
+    update_server.wait_for_update()
     browser.navigate(f'{server.url()}/console_log.png')
     sleep(2)
     res = browser.execute("document.body.innerText")
@@ -241,9 +253,9 @@ def test_in_memory_cache(browser, server, expected, addon_path):
         }, "ERR_WEBCAT_FILE_MISMATCH",
         id="corrupted_js_with_induced_error_test"),
 ], indirect=["root"])
-def test_multiple_tabs(browser: Browser, server: Server, expected, addon_path):
+def test_multiple_tabs(browser: Browser, server: Server, update_server: UpdateServer, expected, addon_path):
     browser.install_extension(addon_path)
-    sleep(7)
+    update_server.wait_for_update()
     browser.execute(
         f"window.open('{server.url()}');"
         f"setTimeout(() => location.href = '{server.url()}/x', 1000)"
@@ -259,7 +271,7 @@ def test_multiple_tabs(browser: Browser, server: Server, expected, addon_path):
         }, "ERR_WEBCAT_FILE_MISMATCH",
         id="non_enrolled_loads_enrolled_subresource_test"),
 ], indirect=["root"])
-def test_non_enrolled_subresource(browser: Browser, server: Server, expected, addon_path, dnsnames, non_enrolled_dnsnames):
+def test_non_enrolled_subresource(browser: Browser, server: Server, update_server: UpdateServer, expected, addon_path, dnsnames, non_enrolled_dnsnames):
     enrolled_url = server.url(dnsnames[0])
     non_enrolled_url = server.url(non_enrolled_dnsnames[0])
     # Non-enrolled landing page that loads a single sub-resource cross-origin
@@ -273,7 +285,7 @@ def test_non_enrolled_subresource(browser: Browser, server: Server, expected, ad
         headers={"content-security-policy": "script-src *"},
     )
     browser.install_extension(addon_path)
-    sleep(7)
+    update_server.wait_for_update()
     browser.navigate(non_enrolled_url)
     sleep(5)
     res = browser.execute("document.body.innerText")
@@ -287,9 +299,9 @@ def test_non_enrolled_subresource(browser: Browser, server: Server, expected, ad
         }, "ERR_WEBCAT_FILE_MISMATCH",
         id="corrupted_js_with_cache_eviction_test"),
 ], indirect=["root"])
-def test_cache_eviction(browser: Browser, server: Server, expected, addon_path, dnsnames):
+def test_cache_eviction(browser: Browser, server: Server, update_server: UpdateServer, expected, addon_path, dnsnames):
     browser.install_extension(addon_path)
-    sleep(7)
+    update_server.wait_for_update()
     browser.execute(
          "const w = window.open();"
         f"window.open('{server.url()}');"
@@ -307,10 +319,10 @@ def test_cache_eviction(browser: Browser, server: Server, expected, addon_path, 
     pytest.param("cases/testapp", EXPECTED_CSP, {}, "Hello v2!",
         id="version_refresh_test"),
 ], indirect=["root"])
-def test_version_refresh(browser: Browser, server: Server, bundle_generator, expected, addon_path, root):
+def test_version_refresh(browser: Browser, server: Server, update_server: UpdateServer, bundle_generator, expected, addon_path, root):
     # Load v0.1: server serves the bundle that the `root` fixture signed.
     browser.install_extension(addon_path)
-    sleep(7)
+    update_server.wait_for_update()
     browser.navigate(server.url())
     sleep(3)
     assert "Hello!" in browser.execute("document.body.innerText")

--- a/test/tests.py
+++ b/test/tests.py
@@ -406,7 +406,7 @@ def test_version_refresh(browser: Browser, server: Server, update_server: Update
 
     # Server now signals a new version and serves the v0.2 bundle + content.
     # The extension should detect x-webcat-version > cached manifest.version,
-    # purge the origin cache, and reload with bypassCache.
+    # purge the origin cache and browser caches, and reload.
     server.hooks["/"] = Hook(v2_index, type="text/html",
                              headers={"x-webcat-version": "0.2"})
     server.hooks["/.well-known/webcat/bundle.json"] = Hook(

--- a/test/tests.py
+++ b/test/tests.py
@@ -158,7 +158,7 @@ def setdiff(a: list, b: list):
     # Hook /wasm/reverseSub.wasm
     pytest.param("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {"/wasm/reverseSub.wasm": BAD_WASM}, "Hello!", setdiff(EXPECTED_LOGS, [LOGENTRY_LOAD_WASMWORKER]), [
             ['Error: [WEBCAT] Unauthorized WebAssembly bytecode: HBppdg6328KAR4wUuqq0tuD4b7l5Wrl9ne6AfB4C0G4', '/workers/wasm_worker.js']
-        ], [], NON_FRAME_PATHS-{"/wasm/reverseSub.wasm"},
+        ], [], NON_FRAME_PATHS,
         id="corrupted_wasm_worker_test"),
 
     # Hook /workers/worker.js

--- a/test/tests.py
+++ b/test/tests.py
@@ -74,7 +74,7 @@ JS_PATHS = set(map(lambda filename: f"/js/{filename}", os.listdir("./cases/testa
 WASM_PATHS = set(map(lambda filename: f"/wasm/{filename}", os.listdir("./cases/testapp/wasm/")))
 WORKER_PATHS = set(map(lambda filename: f"/workers/{filename}", os.listdir("./cases/testapp/workers/")))
 FRAME_PATHS = {"/js/framehost.js", "/wasm/frame_addThree.wasm"}
-ALL_PATHS = {"/"}.union(CSS_PATHS,JS_PATHS,WASM_PATHS,WORKER_PATHS)
+ALL_PATHS = set().union(CSS_PATHS,JS_PATHS,WASM_PATHS,WORKER_PATHS)
 NON_FRAME_PATHS = ALL_PATHS-FRAME_PATHS
 
 def setdiff(a: list, b: list):

--- a/test/tests.py
+++ b/test/tests.py
@@ -74,7 +74,7 @@ JS_PATHS = set(map(lambda filename: f"/js/{filename}", os.listdir("./cases/testa
 WASM_PATHS = set(map(lambda filename: f"/wasm/{filename}", os.listdir("./cases/testapp/wasm/")))
 WORKER_PATHS = set(map(lambda filename: f"/workers/{filename}", os.listdir("./cases/testapp/workers/")))
 FRAME_PATHS = {"/js/framehost.js", "/wasm/frame_addThree.wasm"}
-ALL_PATHS = set().union(CSS_PATHS,JS_PATHS,WASM_PATHS,WORKER_PATHS)
+ALL_PATHS = {"/"}.union(CSS_PATHS,JS_PATHS,WASM_PATHS,WORKER_PATHS)
 NON_FRAME_PATHS = ALL_PATHS-FRAME_PATHS
 
 def setdiff(a: list, b: list):
@@ -200,14 +200,14 @@ def test_webcat(browser, in_frame, server: Server, update_server: UpdateServer, 
     logs, errors, rejections = logs.copy(), errors.copy(), rejections.copy()
     browser.install_extension(addon_path)
     update_server.wait_for_update()
-    if in_frame:
-        browser.navigate(f"{server.url(non_enrolled_dnsnames[0])}/framehost.html?url={server.url(dnsnames[0])}")
-    else:
-        browser.navigate(server.url())
     if isinstance(browser, TorBrowser):
-        server.wait_for(paths_to_wait-{"/workers/serviceworker.js"})
-    else:      
-        server.wait_for(paths_to_wait)
+        paths_to_wait = paths_to_wait-{"/workers/serviceworker.js"}
+    if in_frame:
+        url = f"{server.url(non_enrolled_dnsnames[0])}/framehost.html?url={server.url(dnsnames[0])}"
+    else:
+        url = server.url()
+    with server.wait_for(paths_to_wait):
+        browser.navigate(url)
     if not in_frame:
         res = browser.execute("document.body.innerText")
         assert expected in res
@@ -237,8 +237,8 @@ def test_webcat(browser, in_frame, server: Server, update_server: UpdateServer, 
     }, {"/console_log.png": WEBCAT_ICON}, "ERR_WEBCAT_FILE_MISMATCH"),
 ], indirect=["root"])
 def test_in_memory_cache(browser, server: Server, update_server: UpdateServer, expected, addon_path):
-    browser.navigate(f'{server.url()}/console_log.png')
-    server.wait_for({"/favicon.ico"})
+    with server.wait_for({"/console_log.png"}):
+        browser.navigate(f'{server.url()}/console_log.png')
     browser.install_extension(addon_path)
     update_server.wait_for_update()
     browser.navigate(f'{server.url()}/console_log.png')
@@ -258,11 +258,11 @@ def test_in_memory_cache(browser, server: Server, update_server: UpdateServer, e
 def test_multiple_tabs(browser: Browser, server: Server, update_server: UpdateServer, expected, addon_path):
     browser.install_extension(addon_path)
     update_server.wait_for_update()
-    browser.execute(
-        f"window.open('{server.url()}');"
-        f"setTimeout(() => location.href = '{server.url()}/x', 1000)"
-    )
-    server.wait_for({"/js/alert.js"})
+    with server.wait_for({"/js/alert.js"}):
+        browser.execute(
+            f"window.open('{server.url()}');"
+            f"setTimeout(() => location.href = '{server.url()}/x', 1000)"
+        )
     res = browser.execute("document.body.innerText")
     assert expected in res
 
@@ -288,8 +288,8 @@ def test_non_enrolled_subresource(browser: Browser, server: Server, update_serve
     )
     browser.install_extension(addon_path)
     update_server.wait_for_update()
-    browser.navigate(non_enrolled_url)
-    server.wait_for({"/js/alert.js"})
+    with server.wait_for({"/js/alert.js"}):
+        browser.navigate(non_enrolled_url)
     res = browser.execute("document.body.innerText")
     assert expected in res
 
@@ -304,15 +304,15 @@ def test_non_enrolled_subresource(browser: Browser, server: Server, update_serve
 def test_cache_eviction(browser: Browser, server: Server, update_server: UpdateServer, expected, addon_path, dnsnames):
     browser.install_extension(addon_path)
     update_server.wait_for_update()
-    browser.execute(
-         "const w = window.open();"
-        f"window.open('{server.url()}');"
-         "setTimeout(() => {"
-        f"    w.location.href = '{server.url(dnsnames[0])}/console_log.png';"
-        f"    location.href = '{server.url(dnsnames[1])}/console_log.png';"
-         "}, 1000)"
-    )
-    server.wait_for({"/js/alert.js"})
+    with server.wait_for({"/js/alert.js"}):
+        browser.execute(
+            "const w = window.open();"
+            f"window.open('{server.url()}');"
+            "setTimeout(() => {"
+            f"    w.location.href = '{server.url(dnsnames[0])}/console_log.png';"
+            f"    location.href = '{server.url(dnsnames[1])}/console_log.png';"
+            "}, 1000)"
+        )
     res = browser.execute("document.body.innerText")
     assert expected in res
 
@@ -343,8 +343,8 @@ def test_delegation(browser: Browser, server: Server, update_server: UpdateServe
     update_server.wait_for_update()
     # Subscribe before navigation so we don't miss the "Setting ok icon" line
     browser.attach_extension_console()
-    browser.navigate(f"{server.url(dnsnames[0])}/")
-    server.wait_for(paths_to_wait)
+    with server.wait_for(paths_to_wait):
+        browser.navigate(f"{server.url(dnsnames[0])}/")
 
     # Page loads successfully in both cases
     assert "Hello!" in browser.execute("document.body.innerText")
@@ -376,8 +376,8 @@ def test_version_refresh(browser: Browser, server: Server, update_server: Update
     # Load v0.1: server serves the bundle that the `root` fixture signed.
     browser.install_extension(addon_path)
     update_server.wait_for_update()
-    browser.navigate(server.url())
-    server.wait_for(paths_to_wait)
+    with server.wait_for(paths_to_wait):
+        browser.navigate(server.url())
     assert "Hello!" in browser.execute("document.body.innerText")
 
     # Build a v0.2 bundle signed with the same enrollment as v0.1, with a
@@ -415,8 +415,8 @@ def test_version_refresh(browser: Browser, server: Server, update_server: Update
         v2_bundle, type="application/json",
         headers={"cache-control": "no-store"})
 
-    browser.execute("location.reload()")
-    server.wait_for(paths_to_wait)
+    with server.wait_for(paths_to_wait):
+        browser.execute("location.reload()")
     assert expected in browser.execute("document.body.innerText")
 
 @pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
@@ -431,8 +431,8 @@ def test_in_memory_cache_on_update(browser, server: Server, update_server: Updat
     update_server.wait_for_update()
 
     # load a non-enrolled site into browser cache
-    browser.navigate(f'{server.url(non_enrolled_dnsnames[0])}/console_log.png')
-    server.wait_for({"/favicon.ico"})
+    with server.wait_for({"/console_log.png"}):
+        browser.navigate(f'{server.url(non_enrolled_dnsnames[0])}/console_log.png')
 
     # enroll the site
     with open(f'{root}/.well-known/webcat/bundle.json') as bundle:
@@ -443,7 +443,7 @@ def test_in_memory_cache_on_update(browser, server: Server, update_server: Updat
     
     sleep(2) # wait for the rescheduled update
     server.hooks["/console_log.png"] = WEBCAT_ICON
-    browser.navigate(f'{server.url(non_enrolled_dnsnames[0])}/console_log.png')
-    sleep(2)
+    with server.wait_for({"/console_log.png"}):
+        browser.navigate(f'{server.url(non_enrolled_dnsnames[0])}/console_log.png')
     res = browser.execute("document.body.innerText")
     assert expected in res


### PR DESCRIPTION
Browser caches were not being cleared properly. With this PR, all caches are cleared every time 1) the extension starts 2) a manifest is updated 3) an integration error occurs 4) or a new site is enrolled. The performance hit is non-trivial but [there doesn't appear to be a way to make the `browsingData.remove` API work otherwise](https://github.com/freedomofpress/webcat/issues/137#issuecomment-4541426567).

Tests, for the most part, no longer use `sleep`. Instead there are methods to wait for server events. The test update server exposes an API to reschedule an update. A new test uses that API to check for correct cache behavior on update. The test app uses fixed ports 8080 and 8443 instead of random ports.