### PR TITLE
Improve error pages

### DIFF
--- a/extension/pages/error.css
+++ b/extension/pages/error.css
@@ -1,0 +1,9 @@
+body.webcaterror .title {
+  background-image: url("../icons/light/webcat-error.SVG");
+}
+
+@media (prefers-color-scheme: dark) {
+  body.webcaterror .title {
+    background-image: url("../icons/dark/webcat-error.SVG");
+  }
+}

--- a/extension/pages/error.html
+++ b/extension/pages/error.html
@@ -33,8 +33,8 @@
 
         <div id="errorDebugInformation" hidden="">
           <p id="whatCanYouDo">
-            Most likely nothing: the problem is with the site, not your
-            connection. The code it served does not match what its developers
+            The problem is with the site, not your connection. The code or the
+            environment it served do not match what its developers
             cryptographically signed, so WEBCAT blocked the page to keep you
             safe. You can let the site owner know, or if you believe this is a
             bug open an issue in the

--- a/extension/pages/error.html
+++ b/extension/pages/error.html
@@ -1,35 +1,52 @@
 <!doctype html>
 <html class="in-content-page" lang="en-US">
   <head>
+    <meta charset="utf-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src chrome:; object-src 'none';"
+      content="default-src chrome:; img-src chrome: 'self'; object-src 'none';"
     />
-    <link
-      rel="stylesheet"
-      href="chrome://global/skin/in-content/info-pages.css"
-    />
+    <meta name="color-scheme" content="light dark" />
+    <link rel="icon" href="chrome://global/skin/icons/warning.svg" />
+    <link rel="stylesheet" href="chrome://global/skin/aboutNetError.css" />
+    <link rel="stylesheet" href="error.css" />
     <script src="error.js"></script>
-    <title>Problem Loading Page</title>
+    <title>Warning: Security Risk</title>
   </head>
-  <body>
+  <body class="certerror webcaterror">
     <div class="container">
-      <div class="title">
-        <h1 class="title-text">WEBCAT Integrity Error</h1>
-      </div>
+      <div id="text-container">
+        <div class="title">
+          <h1 class="title-text">Did not verify</h1>
+        </div>
 
-      <div class="description">
-        <p>WEBCAT was unable to verify the integrity of this website.</p>
-
-        <p>
-          If you believe this is a mistake, you may report the issue to the
-          website administrator, or open an issue in the
-          <a href="https://github.com/freedomofpress/webcat"
-            >WEBCAT repository</a
-          >.
+        <p id="errorShortDesc">
+          WEBCAT could not verify that the code served by
+          <span id="error-host">this site</span> matches its signed manifest, so
+          the page was blocked.
         </p>
 
-        <p>Error code: <code id="error-code">Loading...</code></p>
+        <div class="button-container">
+          <button id="advancedButton" aria-expanded="false">Advanced</button>
+          <button id="returnButton" class="primary">Go back</button>
+        </div>
+
+        <div id="errorDebugInformation" hidden="">
+          <p id="whatCanYouDo">
+            Most likely nothing: the problem is with the site, not your
+            connection. The code it served does not match what its developers
+            cryptographically signed, so WEBCAT blocked the page to keep you
+            safe. You can let the site owner know, or if you believe this is a
+            bug open an issue in the
+            <a href="https://github.com/freedomofpress/webcat"
+              >WEBCAT repository</a
+            >.
+          </p>
+          <p class="error-detail" id="debug-file-line" hidden="">
+            File: <span id="debug-file"></span>
+          </p>
+          <p id="errorCode">Error code: <span id="debug-code"></span></p>
+        </div>
       </div>
     </div>
   </body>

--- a/extension/pages/error.js
+++ b/extension/pages/error.js
@@ -1,7 +1,33 @@
 document.addEventListener("DOMContentLoaded", () => {
-  const code = decodeURIComponent(location.hash.slice(1));
-  const el = document.getElementById("error-code");
-  if (el) {
-    el.textContent = code || "UNKNOWN";
+  const params = new URLSearchParams(location.hash.slice(1));
+  const code = params.get("code") || "UNKNOWN";
+  const host = params.get("host") || "";
+  const file = params.get("file") || "";
+
+  setText("error-host", host || "this site");
+  setText("debug-code", code);
+
+  if (file) {
+    setText("debug-file", file);
+    document.getElementById("debug-file-line").hidden = false;
   }
+
+  const advancedButton = document.getElementById("advancedButton");
+  const advancedPanel = document.getElementById("errorDebugInformation");
+  advancedButton.addEventListener("click", () => {
+    advancedPanel.hidden = !advancedPanel.hidden;
+    advancedButton.setAttribute("aria-expanded", String(!advancedPanel.hidden));
+    advancedButton.textContent = advancedPanel.hidden
+      ? "Advanced"
+      : "Hide advanced";
+  });
+
+  // The error page took a history slot
+  document
+    .getElementById("returnButton")
+    .addEventListener("click", () => history.back());
 });
+
+function setText(id, text) {
+  document.getElementById(id).textContent = text;
+}

--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -284,7 +284,7 @@ export async function validateResponseContent(
       errorpage(
         details.tabId,
         fqdn,
-        new WebcatError(WebcatErrorCode.File.MISSING),
+        new WebcatError(WebcatErrorCode.File.MISSING, [pathname]),
       );
       return;
     }
@@ -304,6 +304,7 @@ export async function validateResponseContent(
         details.tabId,
         fqdn,
         new WebcatError(WebcatErrorCode.File.MISMATCH, [
+          pathname,
           String(manifest_hash),
           String(Uint8ArrayToBase64Url(new Uint8Array(content_hash))),
         ]),

--- a/extension/src/webcat/ui.ts
+++ b/extension/src/webcat/ui.ts
@@ -1,4 +1,4 @@
-import { WebcatError } from "./interfaces/errors";
+import { WebcatError, WebcatErrorCode } from "./interfaces/errors";
 import { logger } from "./logger";
 import { clearBrowserCaches, getFQDN } from "./utils";
 
@@ -112,12 +112,24 @@ export async function errorpage(
 
   const code = error?.code ?? "WEBCAT_ERROR_UNDEFINED";
 
+  const params = new URLSearchParams({ code, host: fqdn });
+
+  if (
+    (code === WebcatErrorCode.File.MISMATCH ||
+      code === WebcatErrorCode.File.MISSING) &&
+    error?.details?.[0]
+  ) {
+    params.set("file", error.details[0]);
+  }
+
   const errorPageUrl =
-    browser.runtime.getURL("pages/error.html") + `#${encodeURIComponent(code)}`;
+    browser.runtime.getURL("pages/error.html") + `#${params.toString()}`;
 
   const tabUpdates: Promise<browser.tabs.Tab>[] = [];
   tabIds.forEach((tabId) =>
-    tabUpdates.push(browser.tabs.update(tabId, { url: errorPageUrl })),
+    tabUpdates.push(
+      browser.tabs.update(tabId, { url: errorPageUrl, loadReplace: true }),
+    ),
   );
   await Promise.all(tabUpdates);
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -209,7 +209,7 @@ def test_webcat(browser, in_frame, server: Server, update_server: UpdateServer, 
     with server.wait_for(paths_to_wait):
         browser.navigate(url)
     if not in_frame:
-        res = browser.execute("document.body.innerText")
+        res = browser.execute("document.body.textContent")
         assert expected in res
     res = json.loads(browser.execute("JSON.stringify(window.capture?.logs || [])"))
     for log in res:
@@ -243,7 +243,7 @@ def test_in_memory_cache(browser, server: Server, update_server: UpdateServer, e
     update_server.wait_for_update()
     browser.navigate(f'{server.url()}/console_log.png')
     sleep(2) # loading from cache, so can't use server.wait_for
-    res = browser.execute("document.body.innerText")
+    res = browser.execute("document.body.textContent")
     assert expected in res
 
 @pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
@@ -263,7 +263,7 @@ def test_multiple_tabs(browser: Browser, server: Server, update_server: UpdateSe
             f"window.open('{server.url()}');"
             f"setTimeout(() => location.href = '{server.url()}/x', 1000)"
         )
-    res = browser.execute("document.body.innerText")
+    res = browser.execute("document.body.textContent")
     assert expected in res
 
 @pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
@@ -290,7 +290,7 @@ def test_non_enrolled_subresource(browser: Browser, server: Server, update_serve
     update_server.wait_for_update()
     with server.wait_for({"/js/alert.js"}):
         browser.navigate(non_enrolled_url)
-    res = browser.execute("document.body.innerText")
+    res = browser.execute("document.body.textContent")
     assert expected in res
 
 @pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
@@ -313,7 +313,7 @@ def test_cache_eviction(browser: Browser, server: Server, update_server: UpdateS
             f"    location.href = '{server.url(dnsnames[1])}/console_log.png';"
             "}, 1000)"
         )
-    res = browser.execute("document.body.innerText")
+    res = browser.execute("document.body.textContent")
     assert expected in res
 
 @pytest.mark.parametrize("browser, paths_to_wait", [
@@ -347,7 +347,7 @@ def test_delegation(browser: Browser, server: Server, update_server: UpdateServe
         browser.navigate(f"{server.url(dnsnames[0])}/")
 
     # Page loads successfully in both cases
-    assert "Hello!" in browser.execute("document.body.innerText")
+    assert "Hello!" in browser.execute("document.body.textContent")
 
     logs_blob = json.dumps(browser.extension_logs())
     accepted_marker = f"Setting ok icon (delegation: {delegated_fqdn})"
@@ -378,7 +378,7 @@ def test_version_refresh(browser: Browser, server: Server, update_server: Update
     update_server.wait_for_update()
     with server.wait_for(paths_to_wait):
         browser.navigate(server.url())
-    assert "Hello!" in browser.execute("document.body.innerText")
+    assert "Hello!" in browser.execute("document.body.textContent")
 
     # Build a v0.2 bundle signed with the same enrollment as v0.1, with a
     # modified index.html. The inline <script> block is left untouched so its
@@ -417,7 +417,7 @@ def test_version_refresh(browser: Browser, server: Server, update_server: Update
 
     with server.wait_for(paths_to_wait):
         browser.execute("location.reload()")
-    assert expected in browser.execute("document.body.innerText")
+    assert expected in browser.execute("document.body.textContent")
 
 @pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
 @pytest.mark.parametrize("root, headers, hooks, expected", [
@@ -445,5 +445,5 @@ def test_in_memory_cache_on_update(browser, server: Server, update_server: Updat
     server.hooks["/console_log.png"] = WEBCAT_ICON
     with server.wait_for({"/console_log.png"}):
         browser.navigate(f'{server.url(non_enrolled_dnsnames[0])}/console_log.png')
-    res = browser.execute("document.body.innerText")
+    res = browser.execute("document.body.textContent")
     assert expected in res


### PR DESCRIPTION
Following https://github.com/freedomofpress/webcat/issues/186. We cannot really override a page securely as Firefox does, as they use internal functions that are not exposed to web extensions. The safe action is to navigate away, and the extension page is what we have. I have thus spent some time to better integrate it among the other Firefox errors (the WEBCAT icon is to signal that this is an extension error, cause Firefox doesn't like it when people get blocking errors and they could be blamed).

The page now surfaces the host in the main body, and the error code under "Advanced". If the error is related to a file that is broken or missing from manifest, it will surface the affected path (which could help development).

As @jupenur suggested, we still need a better debugging interface for administrators trying to enroll and having integrity issues, but this is a start.

<img width="1393" height="741" alt="image" src="https://github.com/user-attachments/assets/b6ff2d53-b6e1-453f-98b0-f5c62996d311" />
<img width="1470" height="881" alt="image" src="https://github.com/user-attachments/assets/f209dd0e-425a-4a14-b896-7aee4a43d72c" />
