### PR TITLE
Add auto rerun to integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -95,5 +95,5 @@ jobs:
       - name: Run integration tests
         run: |
           make test TESTARGS="--addon ../dist/webcat-extension-test.zip \
-          --headless -k '${{ matrix.test-filter }}'"
+          --headless --reruns 2 --reruns-delay 5 -k '${{ matrix.test-filter }}'"
 

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -4,3 +4,4 @@ geckordp
 pytest
 pytest-benchmark
 pytest-check
+pytest-rerunfailures


### PR DESCRIPTION
Add `pytest-rerunfailures` to automatically rerun tests in case of flaky CI