### PR TITLE
Ensure the end marker never leaks

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -102,5 +102,5 @@ jobs:
       - name: Run integration tests
         run: |
           make test TESTARGS="--addon ../dist/webcat-extension-test.zip \
-          --headless --reruns 2 --reruns-delay 5 -k '${{ matrix.test-filter }}'"
+          --headless --reruns 2 --reruns-delay 5 --rerun-except Fatal -k '${{ matrix.test-filter }}'"
 

--- a/extension/src/globals.ts
+++ b/extension/src/globals.ts
@@ -3,12 +3,7 @@ import { CacheKey, LRUCache, LRUSet } from "./webcat/cache";
 import { WebcatDatabase } from "./webcat/db";
 import { stringToUint8Array, Uint8ArrayToBase64Url } from "./webcat/encoding";
 import { OriginStateHolder } from "./webcat/interfaces/originstate";
-
-export type CachePartition = { firstParty: string; incognito: boolean };
-export type RequestInfo = {
-  pendingOrigin: OriginStateHolder;
-  cachePartition: CachePartition;
-};
+import { CachePartition, RequestInfo } from "./webcat/interfaces/requestinfo";
 
 export const requestInfo = new Map<string, RequestInfo>();
 export const origins = new LRUCache<

--- a/extension/src/webcat/db.ts
+++ b/extension/src/webcat/db.ts
@@ -1,5 +1,6 @@
-import { CachePartition, nonOrigins, origins } from "../globals"; // caching maps
+import { nonOrigins, origins } from "../globals"; // caching maps
 import { CacheKey } from "./cache";
+import { CachePartition } from "./interfaces/requestinfo";
 import { extractHostname, extractRawHash } from "./parsers";
 
 const META_KEY = "block_meta";

--- a/extension/src/webcat/interfaces/originstate.ts
+++ b/extension/src/webcat/interfaces/originstate.ts
@@ -1,5 +1,5 @@
 import { bundle_name, bundle_prev_name } from "../../config";
-import { CachePartition, db } from "../../globals";
+import { db } from "../../globals";
 import { canonicalize } from "../canonicalize";
 import { stringToUint8Array } from "../encoding";
 import { arraysEqual } from "../utils";
@@ -20,6 +20,7 @@ import {
   SigsumSignatures,
 } from "./bundle";
 import { WebcatError, WebcatErrorCode } from "./errors";
+import { CachePartition } from "./requestinfo";
 
 type BundleFetch = {
   promise: Promise<Response>;

--- a/extension/src/webcat/interfaces/requestinfo.ts
+++ b/extension/src/webcat/interfaces/requestinfo.ts
@@ -1,0 +1,33 @@
+import { OriginStateHolder } from "./originstate";
+
+export type CachePartition = { firstParty: string; incognito: boolean };
+
+export type RequestInfoParams = {
+  pendingOrigin: OriginStateHolder;
+  cachePartition: CachePartition;
+};
+
+export class RequestInfo {
+  pendingOrigin: OriginStateHolder;
+  cachePartition: CachePartition;
+  completed: Promise<void>;
+  #resolve?: () => void;
+  #reject?: () => void;
+
+  constructor({ pendingOrigin, cachePartition }: RequestInfoParams) {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    this.completed = promise;
+    this.complete = resolve;
+    this.fail = reject;
+    this.pendingOrigin = pendingOrigin;
+    this.cachePartition = cachePartition;
+  }
+
+  complete() {
+    this.#resolve?.();
+  }
+
+  fail() {
+    this.#reject?.();
+  }
+}

--- a/extension/src/webcat/listeners.ts
+++ b/extension/src/webcat/listeners.ts
@@ -1,5 +1,5 @@
 import { endpoint } from "../config";
-import { CachePartition, db, origins, requestInfo, tabs } from "../globals";
+import { db, origins, requestInfo, tabs } from "../globals";
 import { CacheKey } from "./cache";
 import type { WebcatDatabase } from "./db";
 import { getHooks } from "./genhooks";
@@ -9,6 +9,7 @@ import {
   OriginStateHolder,
   OriginStateVerifiedManifest,
 } from "./interfaces/originstate";
+import { CachePartition, RequestInfo } from "./interfaces/requestinfo";
 import { logger } from "./logger";
 import { validateOrigin } from "./request";
 import { FRAME_TYPES } from "./resources";
@@ -100,7 +101,6 @@ export async function headersListener(
   }
 
   commitVerifiedOrigin(fqdn, originStateHolder, cachePartition);
-  requestInfo.delete(details.requestId);
 
   markResponseContent(details);
 
@@ -210,10 +210,13 @@ export async function requestListener(
   if (!isFrame) {
     originStateHolder = origins.get(CacheKey(fqdn, cachePartition));
     if (originStateHolder) {
-      requestInfo.set(details.requestId, {
-        pendingOrigin: originStateHolder,
-        cachePartition,
-      });
+      requestInfo.set(
+        details.requestId,
+        new RequestInfo({
+          pendingOrigin: originStateHolder,
+          cachePartition,
+        }),
+      );
     }
   }
 
@@ -259,13 +262,21 @@ export async function requestListener(
 function errorOccurredListener(
   details: browser.webRequest._OnErrorOccurredDetails,
 ): void {
-  requestInfo.delete(details.requestId);
+  const info = requestInfo.get(details.requestId);
+  if (info) {
+    info.fail();
+    requestInfo.delete(details.requestId);
+  }
 }
 
 function completedListener(
   details: browser.webRequest._OnCompletedDetails,
 ): void {
-  requestInfo.delete(details.requestId);
+  const info = requestInfo.get(details.requestId);
+  if (info) {
+    info.complete();
+    requestInfo.delete(details.requestId);
+  }
 }
 
 // Single global webRequest listener registration that scopes to the union

--- a/extension/src/webcat/request.ts
+++ b/extension/src/webcat/request.ts
@@ -1,4 +1,4 @@
-import { CachePartition, db, origins, requestInfo, tabs } from "./../globals";
+import { db, origins, requestInfo, tabs } from "./../globals";
 import { CacheKey } from "./cache";
 import { metadataRequestSource } from "./interfaces/base";
 import { WebcatError, WebcatErrorCode } from "./interfaces/errors";
@@ -7,6 +7,7 @@ import {
   OriginStateHolder,
   OriginStateInitial,
 } from "./interfaces/originstate";
+import { CachePartition, RequestInfo } from "./interfaces/requestinfo";
 import { logger } from "./logger";
 import { setIcon } from "./ui";
 import { enforceHTTPS, validateProtocolAndPort } from "./validators";
@@ -52,7 +53,10 @@ export async function validateOrigin(
   const cached = origins.get(CacheKey(fqdn, cachePartition));
   if (cached) {
     // Pin the holder to this request so later stages cannot race against LRU eviction
-    requestInfo.set(requestId, { pendingOrigin: cached, cachePartition });
+    requestInfo.set(
+      requestId,
+      new RequestInfo({ pendingOrigin: cached, cachePartition }),
+    );
     return;
   }
 
@@ -77,7 +81,10 @@ export async function validateOrigin(
     cachePartition,
   );
   const origin = new OriginStateHolder(newOriginState);
-  requestInfo.set(requestId, { pendingOrigin: origin, cachePartition });
+  requestInfo.set(
+    requestId,
+    new RequestInfo({ pendingOrigin: origin, cachePartition }),
+  );
 
   // See https://github.com/freedomofpress/webcat/issues/95
   await origin.current.fetcher.awaitAll();

--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -239,6 +239,7 @@ export async function validateResponseContent(
 
   const source: Promise<ArrayBuffer>[] = [];
   let writeQueue: Promise<void> = Promise.resolve();
+  let endMarkerSeen = false;
   filter.ondata = (event: { data: ArrayBuffer }) => {
     // The data here is usually chunked; normally it would be streamed down as we get it
     // but since we can hash the content only at the end, we have to wait until we have everything
@@ -261,12 +262,20 @@ export async function validateResponseContent(
         writeQueue = writeQueue.then(async () => filter.write(await hook));
       });
       source.length = 0;
+      endMarkerSeen = true;
     } else {
       source.push(Promise.resolve(event.data));
     }
   };
 
   filter.onstop = async () => {
+    if (!endMarkerSeen && !PASS_THROUGH_TYPES.has(details.type)) {
+      // The request terminated early, before headers were received,
+      // possibly because the user navigated away. Close without
+      // writing anything; don't display an error.
+      filter.close();
+      return;
+    }
     const blob = await new Blob(await Promise.all(source)).arrayBuffer();
 
     // Following order of priority:

--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -1,4 +1,4 @@
-import { CachePartition, endMarker, hookMarker, origins } from "./../globals";
+import { endMarker, hookMarker, origins, requestInfo } from "./../globals";
 import { CacheKey } from "./cache";
 import {
   base64UrlToUint8Array,
@@ -17,6 +17,7 @@ import {
   OriginStateVerifiedEnrollment,
   OriginStateVerifiedManifest,
 } from "./interfaces/originstate";
+import { CachePartition } from "./interfaces/requestinfo";
 import { logger } from "./logger";
 import { PASS_THROUGH_TYPES } from "./resources";
 import { errorpage, setOKIcon } from "./ui";
@@ -268,11 +269,31 @@ export async function validateResponseContent(
     }
   };
 
+  const info = requestInfo.get(details.requestId);
   filter.onstop = async () => {
     if (!endMarkerSeen && !PASS_THROUGH_TYPES.has(details.type)) {
       // The request terminated early, before headers were received,
       // possibly because the user navigated away. Close without
       // writing anything; don't display an error.
+      filter.close();
+      return;
+    }
+    try {
+      // Make sure the response is complete and was not interrupted by a
+      // network error; ignore incomplete responses without displaying an
+      // error. When the request is not associated with a tab, skip the
+      // check as a workaround to a bug in ServiceWorkers:
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=2054048
+      if (details.tabId !== -1) {
+        await info?.completed;
+      }
+    } catch {
+      logger.addLog(
+        "warn",
+        `Request canceled, url: ${details.url}`,
+        details.tabId,
+        fqdn,
+      );
       filter.close();
       return;
     }

--- a/extension/src/webcat/validators.ts
+++ b/extension/src/webcat/validators.ts
@@ -24,7 +24,7 @@ import {
   RawPublicKey,
 } from "@freedomofpress/sigsum/dist/types";
 
-import { CachePartition, db } from "./../globals";
+import { db } from "./../globals";
 import { canonicalize } from "./canonicalize";
 import { base64UrlToUint8Array, stringToUint8Array } from "./encoding";
 import {
@@ -35,6 +35,7 @@ import {
   SigsumSignatures,
 } from "./interfaces/bundle";
 import { WebcatError, WebcatErrorCode } from "./interfaces/errors";
+import { CachePartition } from "./interfaces/requestinfo";
 import { parseContentSecurityPolicy } from "./parsers";
 import { FRAME_TYPES } from "./resources";
 import { getFQDNSafe } from "./utils";

--- a/test/tests.py
+++ b/test/tests.py
@@ -11,6 +11,9 @@ import hashlib
 from pytest_check import check
 import urllib.parse
 
+class Fatal(Exception):
+    pass
+
 logging.getLogger("geckordp").setLevel(logging.CRITICAL)
 logging.getLogger("psutil").setLevel(logging.CRITICAL)
 logging.getLogger().setLevel(logging.WARNING)
@@ -242,6 +245,8 @@ def test_webcat(browser, in_frame, server: Server, update_server: UpdateServer, 
         browser.navigate(url)
     if not in_frame:
         res = browser.execute("document.body.textContent")
+        if "__WEBCAT_" in res:
+            raise Fatal(f"Marker leaked to response content: {res}")
         assert expected in res
     res = json.loads(browser.execute("JSON.stringify(window.capture?.logs || [])"))
     for log in res:


### PR DESCRIPTION
Fixes #206. I was not able to reproduce the leak I saw in #206 and so did not find the root cause. However, this PR fixes another marker-related bug, where, if the browser canceled a script request before receiving headers (for example due to navigating away from the page that issued it), the end marker would not be produced, and WEBCAT would compute the hash for the hooks instead of the empty content. The same fix also guards against the end marker leaking: if the end marker is not seen when expected, the stream filter writes an empty body. That should fully mitigate the security impact of #206.

As for tests, `test_webcat` now fails without retries if a marker is ever seen in the text content.

This also fixes #208, another case related to canceled requests: when partial response content has already been received, and the request is canceled, the response is now ignored.