### PR TITLE
Speed up and harden the integration test harness

### DIFF
--- a/test/benchmarks.py
+++ b/test/benchmarks.py
@@ -25,7 +25,7 @@ js_code = """
 @pytest.mark.parametrize("root", [("cases/testapp")], indirect=True)
 @pytest.mark.parametrize("warm", [(False), (True)], ids=["cold", "warm"])
 @pytest.mark.parametrize("addon_installed, enrolled", [(True, True), (True, False), (False, True)], ids=["enrolled", "not_enrolled", "no_extension"])
-def test_benchmark(root, warm, addon_installed, enrolled, addon_path, request, benchmark):
+def test_benchmark(root, update_server, warm, addon_installed, enrolled, addon_path, request, benchmark):
     def setup():
         server = Server(root=root, headers=EXPECTED_CSP)
         server.start()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -106,9 +106,16 @@ def ssl_cert(dnsnames, non_enrolled_dnsnames):
     return cert_path, key_path
 
 @pytest.fixture(scope="function")
-def update_server():
+def update_server(root, dnsnames):
     us = UpdateServer()
     us.start()
+    with open(f'{root}/.well-known/webcat/bundle.json') as bundle:
+        enrollment = json.load(bundle)["enrollment"]
+        canonical_enrollment = canonicaljson.encode_canonical_json(enrollment)
+        enrollment_hash = hashlib.sha256(canonical_enrollment).hexdigest()
+        us.set("127.0.0.1", enrollment_hash)
+        for name in dnsnames:
+            us.set(name, enrollment_hash)
     yield us
     us.stop()
 
@@ -118,16 +125,13 @@ def bundle_generator():
     yield g
     g.close()
 
+# Session-scoped so the bundle is signed (a network round-trip to the sigsum
+# log) once per session, not once per test. Keep function-scoped fixtures like
+# update_server out of the dependency list: they would tear this fixture down
+# after every test and re-trigger the signing.
 @pytest.fixture(scope="session")
-def root(update_server, dnsnames, request, bundle_generator):
+def root(request, bundle_generator):
     bundle_generator.sign(request.param)
-    with open(f'{request.param}/.well-known/webcat/bundle.json') as bundle:
-        enrollment = json.load(bundle)["enrollment"]
-        canonical_enrollment = canonicaljson.encode_canonical_json(enrollment)
-        enrollment_hash = hashlib.sha256(canonical_enrollment).hexdigest()
-        update_server.set("127.0.0.1", enrollment_hash)
-        for name in dnsnames:
-            update_server.set(name, enrollment_hash)
     return request.param
 
 @pytest.fixture(scope="function")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -125,10 +125,8 @@ def bundle_generator():
     yield g
     g.close()
 
-# Session-scoped so the bundle is signed (a network round-trip to the sigsum
-# log) once per session, not once per test. Keep function-scoped fixtures like
-# update_server out of the dependency list: they would tear this fixture down
-# after every test and re-trigger the signing.
+# Session-scoped so signing (a sigsum network round trip) happens once. A
+# function-scoped dependency here would tear this down after every test.
 @pytest.fixture(scope="session")
 def root(request, bundle_generator):
     bundle_generator.sign(request.param)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -651,10 +651,17 @@ class UpdateServer:
         us._reschedule_in = time_in_seconds
         us._reschedule_once = once
 
-    def wait_for_update(us, count=1, timeout=60):
+    def wait_for_update(us, count=1, timeout=60, settle=1.0):
         """Block until list.json has been served at least `count` times in
         total. Returns immediately if that already happened, so a fetch
-        completing before this call cannot cause a missed wakeup."""
+        completing before this call cannot cause a missed wakeup.
+
+        `settle` then leaves the extension time to finish the rest of the
+        update (verify, store, re-register listeners, clear caches): a page
+        load overlapping that tail can wedge response filtering entirely and
+        freeze the page mid-load, which manifests as wait_for() timeouts on
+        the later subresources. Remove once the extension serializes updates
+        against in-flight requests."""
         deadline = monotonic() + timeout
         with us._update_served:
             while us._update_count < count:
@@ -664,3 +671,4 @@ class UpdateServer:
                         f"timeout waiting for update fetch "
                         f"({us._update_count}/{count} after {timeout}s)")
                 us._update_served.wait(remaining)
+        sleep(settle)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -46,9 +46,7 @@ from geckordp.profile import ProfileManager
 from geckordp.rdp_client import RDPClient
 
 class Browser:
-    # Profile initialization through geckordp launches Firefox twice and waits
-    # for the profile directory to settle (~15s). Do that once per (binary,
-    # profiles path) pair and clone the result for each Browser (~1s).
+    # geckordp profile creation takes ~15s; do it once and clone per browser
     _template_profiles: dict = {}
 
     def __init__(self, override_firefox_path="", override_profiles_path="", additional_configs={}):
@@ -81,9 +79,8 @@ class Browser:
         flags = list(flags or [])
         if headless:
             flags.append("-headless")
-        # wait=False skips geckordp's CPU-settle heuristic (up to 15s on a
-        # loaded machine); the debugger port only opens once the RDP server
-        # is ready, so poll that instead.
+        # wait=False skips geckordp's slow CPU-settle heuristic; we poll the
+        # debugger port and the console instead
         self.proc = Firefox.start(start, self.port, self.profile_name, flags, self.override_firefox_path, False, False)
         logging.info("Firefox started.")
         try:
@@ -103,10 +100,8 @@ class Browser:
             self.client.connect(self.host, self.port)
             logging.info("RDP connection established.")
             self.root = RootActor(self.client)
-            # The RDP port accepts connections slightly before the browser can
-            # service actor requests; a navigate() sent too early is silently
-            # dropped. A full console-evaluation round trip exercises the same
-            # tab-target path a navigation uses, so only return once that works.
+            # a navigate() sent before the tab can service actor requests is
+            # silently dropped, so wait until a console evaluation works
             while True:
                 try:
                     if self.execute("true") is True:
@@ -117,8 +112,7 @@ class Browser:
                     raise RuntimeError("browser tab not responsive within 30s")
                 sleep(0.1)
         except Exception:
-            # A failed start never reaches the fixture teardown; kill the
-            # half-started browser here or it poisons every following test.
+            # teardown never runs if start fails; don't leak the browser
             try:
                 self.proc.kill()
                 self.proc.wait(5)
@@ -135,9 +129,8 @@ class Browser:
             logging.info("Firefox process killed.")
         except:
             pass
-        # Wait for the browser to actually exit and release the debugger
-        # port: otherwise the next test can connect to this dying instance
-        # (and e.g. get responses from its cache instead of the server).
+        # Wait for exit and port release, or the next test's RDP client can
+        # connect to this dying instance.
         proc = getattr(self, "proc", None)
         if proc is not None:
             try:
@@ -157,9 +150,7 @@ class Browser:
                 except OSError:
                     break
                 if monotonic() > deadline:
-                    logging.warning(
-                        f"debugger port {self.port} still open 10s after killing "
-                        f"firefox; next browser start may fail to bind it")
+                    logging.warning(f"debugger port {self.port} still open after kill")
                     break
                 sleep(0.1)
         try:
@@ -183,8 +174,7 @@ class Browser:
                 f.write(f"{name}:{port}\tOID.2.16.840.1.101.3.4.2.1\t{fingerprint}\t{db_key}\n")
 
     def _list_addons(self, timeout=15):
-        # geckordp returns None when an RDP request times out; that happens
-        # transiently on a loaded machine, so retry instead of crashing.
+        # geckordp returns None on transient RDP timeouts; retry
         deadline = monotonic() + timeout
         while True:
             addons = self.root.list_addons()
@@ -260,12 +250,8 @@ class Browser:
         return list(getattr(self, "_ext_logs", []))
 
     def find_tab(self, needle, timeout=5):
-        """Return the first tab whose URL contains `needle`, or None.
-
-        Which tab ends up selected after window.open/error redirects differs
-        between Firefox and Tor Browser and shifts with timing, so tests that
-        expect an error page in *some* tab should use this instead of reading
-        the currently selected tab."""
+        """Return the first tab whose URL contains `needle`, or None. Use for
+        assertions that must not depend on which tab is currently selected."""
         deadline = monotonic() + timeout
         while True:
             for tab in self.root.list_tabs() or []:
@@ -667,24 +653,17 @@ class UpdateServer:
         us._reschedule_in = time_in_seconds
         us._reschedule_once = once
 
-    def wait_for_update(us, count=1, timeout=60, settle=1.0):
-        """Block until list.json has been served at least `count` times in
-        total. Returns immediately if that already happened, so a fetch
-        completing before this call cannot cause a missed wakeup.
-
-        `settle` then leaves the extension time to finish the rest of the
-        update (verify, store, re-register listeners, clear caches): a page
-        load overlapping that tail can wedge response filtering entirely and
-        freeze the page mid-load, which manifests as wait_for() timeouts on
-        the later subresources. Remove once the extension serializes updates
-        against in-flight requests."""
+    def wait_for_update(us, timeout=60, settle=1.0):
+        """Block until list.json has been served at least once; returns
+        immediately if it already was, so an early fetch cannot cause a
+        missed wakeup. `settle` then gives the extension time to finish
+        applying the update: a page load overlapping that tail can wedge
+        response filtering and freeze the page mid-load."""
         deadline = monotonic() + timeout
         with us._update_served:
-            while us._update_count < count:
+            while us._update_count < 1:
                 remaining = deadline - monotonic()
                 if remaining <= 0:
-                    raise RuntimeError(
-                        f"timeout waiting for update fetch "
-                        f"({us._update_count}/{count} after {timeout}s)")
+                    raise RuntimeError(f"no update fetch within {timeout}s")
                 us._update_served.wait(remaining)
         sleep(settle)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -259,6 +259,22 @@ class Browser:
     def extension_logs(self):
         return list(getattr(self, "_ext_logs", []))
 
+    def find_tab(self, needle, timeout=5):
+        """Return the first tab whose URL contains `needle`, or None.
+
+        Which tab ends up selected after window.open/error redirects differs
+        between Firefox and Tor Browser and shifts with timing, so tests that
+        expect an error page in *some* tab should use this instead of reading
+        the currently selected tab."""
+        deadline = monotonic() + timeout
+        while True:
+            for tab in self.root.list_tabs() or []:
+                if needle in (tab.get("url") or ""):
+                    return tab
+            if monotonic() > deadline:
+                return None
+            sleep(0.2)
+
     def navigate(self, url):
         current_tab = self.root.current_tab()
         tab = TabActor(self.client, current_tab["actor"])

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -4,6 +4,7 @@ import json
 import uuid
 import queue
 import logging
+import psutil
 import subprocess
 import os
 import socket
@@ -45,6 +46,28 @@ from geckordp.firefox import Firefox, _kill_instances
 from geckordp.profile import ProfileManager
 from geckordp.rdp_client import RDPClient
 
+def kill_tree(proc, timeout=10):
+    """Terminate a process and all its children. Killing only the browser
+    leaves e.g. Tor Browser's tor daemon behind, which keeps holding the
+    shared Tor data directory and ports and makes every later Tor Browser
+    start fail with 'Tor exited during startup'."""
+    try:
+        procs = [psutil.Process(proc.pid)]
+        procs += procs[0].children(recursive=True)
+    except psutil.NoSuchProcess:
+        return
+    for p in procs:
+        try:
+            p.terminate()
+        except psutil.NoSuchProcess:
+            pass
+    _, alive = psutil.wait_procs(procs, timeout=timeout)
+    for p in alive:
+        try:
+            p.kill()
+        except psutil.NoSuchProcess:
+            pass
+
 class Browser:
     # geckordp profile creation takes ~15s; do it once and clone per browser
     _template_profiles: dict = {}
@@ -59,6 +82,12 @@ class Browser:
         if template is None:
             template = f"geckordp-template-{uuid.uuid4()}"
             self.pm.create(template)
+            # geckordp initializes the profile by launching the browser; kill
+            # any instance that survived it, or its leftovers (e.g. the tor
+            # daemon) block every later browser start
+            for p in psutil.process_iter(["cmdline"]):
+                if template in " ".join(p.info["cmdline"] or []):
+                    kill_tree(p)
             Browser._template_profiles[template_key] = template
             atexit.register(self.pm.remove, template)
         self.pm.clone(template, self.profile_name, ignore_invalid_files=True)
@@ -79,6 +108,15 @@ class Browser:
         flags = list(flags or [])
         if headless:
             flags.append("-headless")
+        # fail fast if a stale browser still holds the debugger port; the RDP
+        # client would otherwise silently connect to the wrong instance
+        try:
+            socket.create_connection((self.host, self.port), timeout=0.2).close()
+            stale = True
+        except OSError:
+            stale = False
+        if stale:
+            raise RuntimeError(f"debugger port {self.port} is already in use")
         # wait=False skips geckordp's slow CPU-settle heuristic; we poll the
         # debugger port and the console instead
         self.proc = Firefox.start(start, self.port, self.profile_name, flags, self.override_firefox_path, False, False)
@@ -113,11 +151,7 @@ class Browser:
                 sleep(0.1)
         except Exception:
             # teardown never runs if start fails; don't leak the browser
-            try:
-                self.proc.kill()
-                self.proc.wait(5)
-            except Exception:
-                pass
+            kill_tree(self.proc)
             raise
     
     def destroy(self):
@@ -133,15 +167,7 @@ class Browser:
         # connect to this dying instance.
         proc = getattr(self, "proc", None)
         if proc is not None:
-            try:
-                proc.terminate()
-                proc.wait(10)
-            except Exception:
-                try:
-                    proc.kill()
-                    proc.wait(5)
-                except Exception:
-                    pass
+            kill_tree(proc)
         if hasattr(self, "port"):
             deadline = monotonic() + 10
             while True:
@@ -248,18 +274,6 @@ class Browser:
 
     def extension_logs(self):
         return list(getattr(self, "_ext_logs", []))
-
-    def find_tab(self, needle, timeout=5):
-        """Return the first tab whose URL contains `needle`, or None. Use for
-        assertions that must not depend on which tab is currently selected."""
-        deadline = monotonic() + timeout
-        while True:
-            for tab in self.root.list_tabs() or []:
-                if needle in (tab.get("url") or ""):
-                    return tab
-            if monotonic() > deadline:
-                return None
-            sleep(0.2)
 
     def navigate(self, url):
         current_tab = self.root.current_tab()

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
+import atexit
 import json
 import uuid
 import queue
 import logging
 import subprocess
 import os
+import socket
 import ssl
 import sys
 import threading
@@ -15,7 +17,7 @@ import datetime
 import ipaddress
 from base64 import b64decode, b64encode
 from pathlib import Path
-from time import sleep
+from time import sleep, monotonic
 
 from cryptography import x509
 from cryptography.x509.oid import NameOID
@@ -44,12 +46,24 @@ from geckordp.profile import ProfileManager
 from geckordp.rdp_client import RDPClient
 
 class Browser:
+    # Profile initialization through geckordp launches Firefox twice and waits
+    # for the profile directory to settle (~15s). Do that once per (binary,
+    # profiles path) pair and clone the result for each Browser (~1s).
+    _template_profiles: dict = {}
+
     def __init__(self, override_firefox_path="", override_profiles_path="", additional_configs={}):
         self.host = "127.0.0.1"
         self.profile_name = f"geckordp-{uuid.uuid4()}"
         self.override_firefox_path = override_firefox_path
         self.pm = ProfileManager(override_firefox_path, override_profiles_path)
-        self.pm.create(self.profile_name)
+        template_key = (str(override_firefox_path), str(override_profiles_path))
+        template = Browser._template_profiles.get(template_key)
+        if template is None:
+            template = f"geckordp-template-{uuid.uuid4()}"
+            self.pm.create(template)
+            Browser._template_profiles[template_key] = template
+            atexit.register(self.pm.remove, template)
+        self.pm.clone(template, self.profile_name, ignore_invalid_files=True)
         profile = self.pm.get_profile_by_name(self.profile_name)
         self.profile_path = profile.path
         profile.set_required_configs()
@@ -62,16 +76,55 @@ class Browser:
         logging.info(f"Profile {self.profile_name} created.")
         subprocess.Popen(["pkill", "-f", f'\\-P {self.profile_name}']) # TBB hack
 
-    def start(self, headless=False, start="about:blank", flags=[], port=6000):
+    def start(self, headless=False, start="about:blank", flags=None, port=6000):
         self.port = port
+        flags = list(flags or [])
         if headless:
             flags.append("-headless")
-        Firefox.start(start, self.port, self.profile_name, flags, self.override_firefox_path, False)
+        # wait=False skips geckordp's CPU-settle heuristic (up to 15s on a
+        # loaded machine); the debugger port only opens once the RDP server
+        # is ready, so poll that instead.
+        self.proc = Firefox.start(start, self.port, self.profile_name, flags, self.override_firefox_path, False, False)
         logging.info("Firefox started.")
-        self.client = RDPClient()
-        self.client.connect(self.host, self.port)
-        logging.info("RDP connection established.")
-        self.root = RootActor(self.client)
+        try:
+            deadline = monotonic() + 30
+            while True:
+                if self.proc.poll() is not None:
+                    raise RuntimeError(
+                        f"firefox exited during startup (code {self.proc.returncode})")
+                try:
+                    socket.create_connection((self.host, self.port), timeout=1).close()
+                    break
+                except OSError:
+                    if monotonic() > deadline:
+                        raise RuntimeError(f"debugger port {self.port} did not open within 30s")
+                    sleep(0.1)
+            self.client = RDPClient()
+            self.client.connect(self.host, self.port)
+            logging.info("RDP connection established.")
+            self.root = RootActor(self.client)
+            # The RDP port accepts connections slightly before the browser can
+            # service actor requests; a navigate() sent too early is silently
+            # dropped. A full console-evaluation round trip exercises the same
+            # tab-target path a navigation uses, so only return once that works.
+            while True:
+                try:
+                    if self.execute("true") is True:
+                        break
+                except Exception:
+                    pass
+                if monotonic() > deadline:
+                    raise RuntimeError("browser tab not responsive within 30s")
+                sleep(0.1)
+        except Exception:
+            # A failed start never reaches the fixture teardown; kill the
+            # half-started browser here or it poisons every following test.
+            try:
+                self.proc.kill()
+                self.proc.wait(5)
+            except Exception:
+                pass
+            raise
     
     def destroy(self):
         self.client.disconnect()
@@ -82,6 +135,33 @@ class Browser:
             logging.info("Firefox process killed.")
         except:
             pass
+        # Wait for the browser to actually exit and release the debugger
+        # port: otherwise the next test can connect to this dying instance
+        # (and e.g. get responses from its cache instead of the server).
+        proc = getattr(self, "proc", None)
+        if proc is not None:
+            try:
+                proc.terminate()
+                proc.wait(10)
+            except Exception:
+                try:
+                    proc.kill()
+                    proc.wait(5)
+                except Exception:
+                    pass
+        if hasattr(self, "port"):
+            deadline = monotonic() + 10
+            while True:
+                try:
+                    socket.create_connection((self.host, self.port), timeout=0.2).close()
+                except OSError:
+                    break
+                if monotonic() > deadline:
+                    logging.warning(
+                        f"debugger port {self.port} still open 10s after killing "
+                        f"firefox; next browser start may fail to bind it")
+                    break
+                sleep(0.1)
         try:
             self.pm.remove(self.profile_name)
             logging.info(f"Profile {self.profile_name} removed.")
@@ -102,9 +182,22 @@ class Browser:
             for name in dnsnames:
                 f.write(f"{name}:{port}\tOID.2.16.840.1.101.3.4.2.1\t{fingerprint}\t{db_key}\n")
 
+    def _list_addons(self, timeout=15):
+        # geckordp returns None when an RDP request times out; that happens
+        # transiently on a loaded machine, so retry instead of crashing.
+        deadline = monotonic() + timeout
+        while True:
+            addons = self.root.list_addons()
+            if addons is not None:
+                return addons
+            if monotonic() > deadline:
+                raise RuntimeError(f"list_addons unresponsive for {timeout}s")
+            logging.warning("list_addons returned None, retrying")
+            sleep(0.5)
+
     def install_extension(self, path):
         root_actor_ids = self.root.get_root()
-        addons = [addon for addon in self.root.list_addons() if path in addon.get("url", "")]
+        addons = [addon for addon in self._list_addons() if path in addon.get("url", "")]
         if not addons:
             logging.info(f"Installing temporary addon from {path}")
             response = AddonsActor(self.client, root_actor_ids["addonsActor"]).install_temporary_addon(path)
@@ -120,7 +213,7 @@ class Browser:
 
     def attach_extension_console(self, addon_match="webcat"):
         # Subscribe to console-message resources from the extension's targets
-        addons = self.root.list_addons()
+        addons = self._list_addons()
         addon = next(
             (a for a in addons
              if addon_match in (a.get("id") or "")
@@ -453,10 +546,11 @@ class UpdateServer:
         parts.reverse()
         return f"canonical/.{".".join(parts)}"
     
-    def __init__(us): 
+    def __init__(us):
         us._reschedule_in = None
         us._reschedule_once = False
         us._update_served = threading.Condition()
+        us._update_count = 0
         us._hosts = {}
 
     def start(us):
@@ -478,6 +572,7 @@ class UpdateServer:
                     }
                     self.wfile.write(json.dumps(list).encode())
                     with us._update_served:
+                        us._update_count += 1
                         us._update_served.notify_all()
                 elif self.path == "/block.json":
                     self.send_response(200)
@@ -556,6 +651,16 @@ class UpdateServer:
         us._reschedule_in = time_in_seconds
         us._reschedule_once = once
 
-    def wait_for_update(us):
+    def wait_for_update(us, count=1, timeout=60):
+        """Block until list.json has been served at least `count` times in
+        total. Returns immediately if that already happened, so a fetch
+        completing before this call cannot cause a missed wakeup."""
+        deadline = monotonic() + timeout
         with us._update_served:
-            us._update_served.wait()
+            while us._update_count < count:
+                remaining = deadline - monotonic()
+                if remaining <= 0:
+                    raise RuntimeError(
+                        f"timeout waiting for update fetch "
+                        f"({us._update_count}/{count} after {timeout}s)")
+                us._update_served.wait(remaining)

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,6 +1,7 @@
 canonicaljson
 cryptography
 geckordp
+psutil
 pytest
 pytest-benchmark
 pytest-check

--- a/test/tests.py
+++ b/test/tests.py
@@ -301,8 +301,6 @@ def test_multiple_tabs(browser: Browser, server: Server, update_server: UpdateSe
             f"window.open('{server.url()}');"
             f"setTimeout(() => location.href = '{server.url()}/x', 1000)"
         )
-    # Which tab ends up selected differs between Firefox and Tor Browser;
-    # the corrupted script must be blocked in whichever tab loaded it.
     assert browser.find_tab(expected), \
         f"no tab showing {expected}: {[t.get('url') for t in browser.root.list_tabs()]}"
 
@@ -353,8 +351,6 @@ def test_cache_eviction(browser: Browser, server: Server, update_server: UpdateS
             f"    location.href = '{server.url(dnsnames[1])}/console_log.png';"
             "}, 1000)"
         )
-    # Which tab ends up selected differs between Firefox and Tor Browser;
-    # the evicted-and-corrupted file must be blocked in whichever tab loaded it.
     assert browser.find_tab(expected), \
         f"no tab showing {expected}: {[t.get('url') for t in browser.root.list_tabs()]}"
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -301,8 +301,10 @@ def test_multiple_tabs(browser: Browser, server: Server, update_server: UpdateSe
             f"window.open('{server.url()}');"
             f"setTimeout(() => location.href = '{server.url()}/x', 1000)"
         )
-    res = browser.execute("document.body.textContent")
-    assert expected in res
+    # Which tab ends up selected differs between Firefox and Tor Browser;
+    # the corrupted script must be blocked in whichever tab loaded it.
+    assert browser.find_tab(expected), \
+        f"no tab showing {expected}: {[t.get('url') for t in browser.root.list_tabs()]}"
 
 @pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
 @pytest.mark.parametrize("root, headers, hooks, expected", [
@@ -351,8 +353,10 @@ def test_cache_eviction(browser: Browser, server: Server, update_server: UpdateS
             f"    location.href = '{server.url(dnsnames[1])}/console_log.png';"
             "}, 1000)"
         )
-    res = browser.execute("document.body.textContent")
-    assert expected in res
+    # Which tab ends up selected differs between Firefox and Tor Browser;
+    # the evicted-and-corrupted file must be blocked in whichever tab loaded it.
+    assert browser.find_tab(expected), \
+        f"no tab showing {expected}: {[t.get('url') for t in browser.root.list_tabs()]}"
 
 @pytest.mark.parametrize("browser, paths_to_wait", [
     pytest.param("firefox", NON_FRAME_PATHS, id="firefox"),

--- a/test/tests.py
+++ b/test/tests.py
@@ -301,8 +301,8 @@ def test_multiple_tabs(browser: Browser, server: Server, update_server: UpdateSe
             f"window.open('{server.url()}');"
             f"setTimeout(() => location.href = '{server.url()}/x', 1000)"
         )
-    assert browser.find_tab(expected), \
-        f"no tab showing {expected}: {[t.get('url') for t in browser.root.list_tabs()]}"
+    res = browser.execute("document.body.textContent")
+    assert expected in res
 
 @pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
 @pytest.mark.parametrize("root, headers, hooks, expected", [
@@ -351,8 +351,8 @@ def test_cache_eviction(browser: Browser, server: Server, update_server: UpdateS
             f"    location.href = '{server.url(dnsnames[1])}/console_log.png';"
             "}, 1000)"
         )
-    assert browser.find_tab(expected), \
-        f"no tab showing {expected}: {[t.get('url') for t in browser.root.list_tabs()]}"
+    res = browser.execute("document.body.textContent")
+    assert expected in res
 
 @pytest.mark.parametrize("browser, paths_to_wait", [
     pytest.param("firefox", NON_FRAME_PATHS, id="firefox"),


### PR DESCRIPTION
It seems like the speedup is significant, from the 2+ hours to around ~10 minutes max.

- Fix a race in `UpdateServer.wait_for_update()`: if the extension fetched `list.json` before the wait started, the test blocked until the next update alarm, 5 minutes later. 
- Cut per-test setup from ~30s to ~10s: create the Firefox profile once and clone it per test, sign the bundle once per session instead of per test, and replace geckordp's CPU-settle startup heuristic with polling the debugger.
- `destroy()` waits for Firefox to exit and release the debugger port; a failed start() kills the half-started browser.
- test_multiple_tabs / test_cache_eviction: assert the error page in any tab (Browser.find_tab()) instead of the selected one, which differs between Firefox and Tor Browser.
