### PR TITLE
Move remaining browser API handlers from background.ts to WebcatRequestHandler

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -9,28 +9,12 @@ import validator_set from "./validator_set.json";
 import { isInPartition } from "./webcat/cache";
 import { WebcatDatabase } from "./webcat/db";
 import { WebcatRequestHandler } from "./webcat/handler";
-import { setErrorIcon } from "./webcat/ui";
 import { EnrollmentUpdater } from "./webcat/updater";
 import { clearBrowserCaches } from "./webcat/utils";
 
 console.log("[webcat] Starting up background");
 
 const db = new WebcatDatabase();
-
-// Not the best performance idea to act on all tab just for this
-browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  const errorUrl = browser.runtime.getURL("pages/error.html");
-  if (changeInfo.status === "complete" && tab.url?.startsWith(errorUrl)) {
-    setErrorIcon(tabId);
-  }
-});
-
-// Grey out and make page action unclickable unless a website is enrolled
-browser.tabs.onCreated.addListener((tab) => {
-  if (tab.id !== undefined) {
-    browser.pageAction.hide(tab.id);
-  }
-});
 
 // Handle incognito sessions ending
 browser.windows.onRemoved.addListener(async () => {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -6,7 +6,6 @@ import {
   UPDATE_INTERVAL_MS,
 } from "./config";
 import validator_set from "./validator_set.json";
-import { isInPartition } from "./webcat/cache";
 import { WebcatDatabase } from "./webcat/db";
 import { WebcatRequestHandler } from "./webcat/handler";
 import { EnrollmentUpdater } from "./webcat/updater";
@@ -15,23 +14,6 @@ import { clearBrowserCaches } from "./webcat/utils";
 console.log("[webcat] Starting up background");
 
 const db = new WebcatDatabase();
-
-// Handle incognito sessions ending
-browser.windows.onRemoved.addListener(async () => {
-  const windows = await browser.windows.getAll();
-  if (windows.filter((win) => win.incognito).length === 0) {
-    for (const key of db.origins.keys()) {
-      if (isInPartition(key, { incognito: true })) {
-        db.origins.delete(key);
-      }
-    }
-    for (const value of db.nonOrigins.values()) {
-      if (isInPartition(value, { incognito: true })) {
-        db.nonOrigins.delete(value);
-      }
-    }
-  }
-});
 
 const requestHandler = new WebcatRequestHandler(db);
 const updater = new EnrollmentUpdater({

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -6,7 +6,6 @@ import {
   UPDATE_INTERVAL_MS,
 } from "./config";
 import validator_set from "./validator_set.json";
-import { isInPartition } from "./webcat/cache";
 import { WebcatDatabase } from "./webcat/db";
 import { WebcatRequestHandler } from "./webcat/handler";
 import { EnrollmentUpdater } from "./webcat/updater";
@@ -15,23 +14,6 @@ import { clearBrowserCaches } from "./webcat/utils";
 console.log("[webcat] Starting up background");
 
 const db = new WebcatDatabase();
-
-// Handle incognito sessions ending
-browser.windows.onRemoved.addListener(async () => {
-  const windows = await browser.windows.getAll();
-  if (windows.filter((win) => win.incognito).length === 0) {
-    for (const key of await db.origins.keys()) {
-      if (isInPartition(key, { incognito: true })) {
-        await db.origins.delete(key);
-      }
-    }
-    for (const value of await db.nonOrigins.values()) {
-      if (isInPartition(value, { incognito: true })) {
-        await db.nonOrigins.delete(value);
-      }
-    }
-  }
-});
 
 const requestHandler = new WebcatRequestHandler(db);
 const updater = new EnrollmentUpdater({

--- a/extension/src/webcat/handler.ts
+++ b/extension/src/webcat/handler.ts
@@ -16,7 +16,7 @@ import { logger } from "./logger";
 import { validateOrigin } from "./request";
 import { FRAME_TYPES } from "./resources";
 import { ResponseValidator } from "./response";
-import { errorpage } from "./ui";
+import { errorpage, setErrorIcon } from "./ui";
 import { getFQDN, isExtensionRequest, isNewerSemver } from "./utils";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -44,6 +44,13 @@ export class WebcatRequestHandler extends RequestHandler {
     this.#responseValidator = new ResponseValidator(this.#db, this.#hooks);
     this.addEventListener("beforerequest", this.#onRequest);
     this.addEventListener("headersreceived", this.#onHeaders);
+    browser.webNavigation.onCommitted.addListener(this.#onErrorPageNavigation, {
+      url: [
+        {
+          urlPrefix: browser.runtime.getURL("pages/error.html"),
+        },
+      ],
+    });
   }
 
   override async bind(fqdns: string[]): Promise<string[]> {
@@ -332,5 +339,9 @@ export class WebcatRequestHandler extends RequestHandler {
       getFQDN(details.url),
     );
     return details.requestId;
+  }
+
+  #onErrorPageNavigation(details: browser.webNavigation._OnCommittedDetails) {
+    setErrorIcon(details.tabId);
   }
 }

--- a/extension/src/webcat/handler.ts
+++ b/extension/src/webcat/handler.ts
@@ -6,7 +6,7 @@ import {
   RequestHandler,
 } from "../browser/requests";
 import { ContentScript } from "../browser/scripting";
-import { CacheKey } from "./cache";
+import { CacheKey, isInPartition } from "./cache";
 import { HookBuilder } from "./hookbuilder";
 import { Database } from "./interfaces/database";
 import { WebcatError } from "./interfaces/errors";
@@ -44,13 +44,17 @@ export class WebcatRequestHandler extends RequestHandler {
     this.#responseValidator = new ResponseValidator(this.#db, this.#hooks);
     this.addEventListener("beforerequest", this.#onRequest);
     this.addEventListener("headersreceived", this.#onHeaders);
-    browser.webNavigation.onCommitted.addListener(this.#onErrorPageNavigation, {
-      url: [
-        {
-          urlPrefix: browser.runtime.getURL("pages/error.html"),
-        },
-      ],
-    });
+    browser.webNavigation.onCommitted.addListener(
+      this.#onErrorPageNavigation.bind(this),
+      {
+        url: [
+          {
+            urlPrefix: browser.runtime.getURL("pages/error.html"),
+          },
+        ],
+      },
+    );
+    browser.windows.onRemoved.addListener(this.#onWindowClosed.bind(this));
   }
 
   override async bind(fqdns: string[]): Promise<string[]> {
@@ -343,5 +347,22 @@ export class WebcatRequestHandler extends RequestHandler {
 
   #onErrorPageNavigation(details: browser.webNavigation._OnCommittedDetails) {
     setErrorIcon(details.tabId);
+  }
+
+  async #onWindowClosed() {
+    // Handle incognito sessions ending
+    const windows = await browser.windows.getAll();
+    if (windows.filter((win) => win.incognito).length === 0) {
+      for (const key of await this.#db.origins.keys()) {
+        if (isInPartition(key, { incognito: true })) {
+          this.#db.origins.delete(key);
+        }
+      }
+      for (const value of await this.#db.nonOrigins.values()) {
+        if (isInPartition(value, { incognito: true })) {
+          this.#db.nonOrigins.delete(value);
+        }
+      }
+    }
   }
 }

--- a/extension/src/webcat/handler.ts
+++ b/extension/src/webcat/handler.ts
@@ -6,7 +6,7 @@ import {
   RequestHandler,
 } from "../browser/requests";
 import { ContentScript } from "../browser/scripting";
-import { CacheKey } from "./cache";
+import { CacheKey, isInPartition } from "./cache";
 import { HookBuilder } from "./hookbuilder";
 import { Database } from "./interfaces/database";
 import { WebcatError } from "./interfaces/errors";
@@ -44,13 +44,17 @@ export class WebcatRequestHandler extends RequestHandler {
     this.#responseValidator = new ResponseValidator(this.#db, this.#hooks);
     this.addEventListener("beforerequest", this.#onRequest);
     this.addEventListener("headersreceived", this.#onHeaders);
-    browser.webNavigation.onCommitted.addListener(this.#onErrorPageNavigation, {
-      url: [
-        {
-          urlPrefix: browser.runtime.getURL("pages/error.html"),
-        },
-      ],
-    });
+    browser.webNavigation.onCommitted.addListener(
+      this.#onErrorPageNavigation.bind(this),
+      {
+        url: [
+          {
+            urlPrefix: browser.runtime.getURL("pages/error.html"),
+          },
+        ],
+      },
+    );
+    browser.windows.onRemoved.addListener(this.#onWindowClosed.bind(this));
   }
 
   override async bind(fqdns: string[]): Promise<string[]> {
@@ -308,5 +312,22 @@ export class WebcatRequestHandler extends RequestHandler {
 
   #onErrorPageNavigation(details: browser.webNavigation._OnCommittedDetails) {
     setErrorIcon(details.tabId);
+  }
+
+  async #onWindowClosed() {
+    // Handle incognito sessions ending
+    const windows = await browser.windows.getAll();
+    if (windows.filter((win) => win.incognito).length === 0) {
+      for (const key of this.#db.origins.keys()) {
+        if (isInPartition(key, { incognito: true })) {
+          this.#db.origins.delete(key);
+        }
+      }
+      for (const value of this.#db.nonOrigins.values()) {
+        if (isInPartition(value, { incognito: true })) {
+          this.#db.nonOrigins.delete(value);
+        }
+      }
+    }
   }
 }

--- a/extension/src/webcat/handler.ts
+++ b/extension/src/webcat/handler.ts
@@ -17,7 +17,7 @@ import { OriginStateVerifiedManifest } from "./originstate";
 import { validateOrigin } from "./request";
 import { FRAME_TYPES } from "./resources";
 import { ResponseValidator } from "./response";
-import { errorpage } from "./ui";
+import { errorpage, setErrorIcon } from "./ui";
 import { getFQDN, isExtensionRequest, isNewerSemver } from "./utils";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -44,6 +44,13 @@ export class WebcatRequestHandler extends RequestHandler {
     this.#responseValidator = new ResponseValidator(this.#db, this.#hooks);
     this.addEventListener("beforerequest", this.#onRequest);
     this.addEventListener("headersreceived", this.#onHeaders);
+    browser.webNavigation.onCommitted.addListener(this.#onErrorPageNavigation, {
+      url: [
+        {
+          urlPrefix: browser.runtime.getURL("pages/error.html"),
+        },
+      ],
+    });
   }
 
   override async bind(fqdns: string[]): Promise<string[]> {
@@ -297,5 +304,9 @@ export class WebcatRequestHandler extends RequestHandler {
       getFQDN(details.url),
     );
     return details.requestId;
+  }
+
+  #onErrorPageNavigation(details: browser.webNavigation._OnCommittedDetails) {
+    setErrorIcon(details.tabId);
   }
 }


### PR DESCRIPTION
A small step towards packaging the extension as a library: include all necessary handlers in WebRequestHandler so that there's a single clear public API.