### PR TITLE
Fix the error page 'Go back' button

### DIFF
--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -444,6 +444,7 @@ export class ResponseValidator {
         errorpage(
           details,
           new WebcatError(WebcatErrorCode.File.MISSING, [pathname]),
+          true,
         );
         return;
       }
@@ -466,6 +467,7 @@ export class ResponseValidator {
             String(manifest_hash),
             String(Uint8ArrayToBase64Url(new Uint8Array(content_hash))),
           ]),
+          true,
         );
         return;
       }

--- a/extension/src/webcat/ui.ts
+++ b/extension/src/webcat/ui.ts
@@ -81,6 +81,7 @@ export function setErrorIcon(tabId: number) {
 export async function errorpage(
   details: Stateful<RequestDetails>,
   error?: WebcatError,
+  replace = !details.state.isFrame,
 ) {
   const tabIds = new Set<number>();
   const frameLookups = [];
@@ -134,7 +135,7 @@ export async function errorpage(
     tabUpdates.push(
       browser.tabs.update(tabId, {
         url: errorPageUrl,
-        loadReplace: !details.state.isFrame,
+        loadReplace: replace,
       }),
     ),
   );


### PR DESCRIPTION
The back button behavior regressed in the big refactor PR #210: when an error occurred while validating the content for a frame navigation, the 'Go back' button on the error page does not take you back. The browser's own back button still works for some reason. This PR fixes the behavior by passing the correct `loadReplace` value to the `browser.tabs.update` call.