### PR TITLE
Prefix i18n message names

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -1,23 +1,23 @@
 {
-  "advanced": {
+  "WEBCAT_advanced": {
     "message": "Advanced"
   },
-  "hideAdvanced": {
+  "WEBCAT_hideAdvanced": {
     "message": "Hide advanced"
   },
-  "thisSite": {
+  "WEBCAT_thisSite": {
     "message": "this site"
   },
-  "webcatVerificationSuccessful": {
+  "WEBCAT_webcatVerificationSuccessful": {
     "message": "WEBCAT verification successful"
   },
-  "webcatVerificationFailed": {
+  "WEBCAT_webcatVerificationFailed": {
     "message": "WEBCAT verification failed"
   },
-  "webcatIsRunning": {
+  "WEBCAT_webcatIsRunning": {
     "message": "WEBCAT is running"
   },
-  "webcatIsUnavailable": {
+  "WEBCAT_webcatIsUnavailable": {
     "message": "WEBCAT unavailable on this site."
   }
 }

--- a/extension/_locales/fi/messages.json
+++ b/extension/_locales/fi/messages.json
@@ -1,47 +1,47 @@
 {
-  "warningSecurityRisk": {
+  "WEBCAT_warningSecurityRisk": {
     "message": "Varoitus: Tietoturvariski"
   },
-  "didNotVerify": {
+  "WEBCAT_didNotVerify": {
     "message": "Ei varmennettu"
   },
-  "errorShortDesc": {
+  "WEBCAT_errorShortDesc": {
     "message": "WEBCAT ei voinut varmentaa, että koodi, jonka $1 tarjoili, vastaa allekirjoitettua manifestia, joten sivu estettiin."
   },
-  "thisSite": {
+  "WEBCAT_thisSite": {
     "message": "tämä sivusto"
   },
-  "advanced": {
+  "WEBCAT_advanced": {
     "message": "Lisätietoja"
   },
-  "hideAdvanced": {
+  "WEBCAT_hideAdvanced": {
     "message": "Piilota lisätiedot"
   },
-  "goBack": {
+  "WEBCAT_goBack": {
     "message": "Palaa takaisin"
   },
-  "whatYouCanDo": {
+  "WEBCAT_whatYouCanDo": {
     "message": "Ongelma johtuu sivustosta, ei verkkoyhteydestäsi. Koodi tai ympäristö, jonka sivusto tarjoili, ei vastaa sen kehittäjien kryptografista allekirjoitusta, joten WEBCAT esti sivun pitääkseen sinut turvassa. Voit ilmoittaa ongelmasta sivuston omistajalle, tai jos luulet tämän olevan bugi, raportoida sen $1."
   },
-  "webcatRepository": {
+  "WEBCAT_webcatRepository": {
     "message": "WEBCATin tietovarastoon"
   },
-  "file": {
+  "WEBCAT_file": {
     "message": "Tiedosto: $1"
   },
-  "errorCode": {
+  "WEBCAT_errorCode": {
     "message": "Virhekoodi: $1"
   },
-  "webcatVerificationSuccessful": {
+  "WEBCAT_webcatVerificationSuccessful": {
     "message": "WEBCAT-varmennus onnistui"
   },
-  "webcatVerificationFailed": {
+  "WEBCAT_webcatVerificationFailed": {
     "message": "WEBCAT-varmennus epäonnistui"
   },
-  "webcatIsRunning": {
+  "WEBCAT_webcatIsRunning": {
     "message": "WEBCAT on käynnissä"
   },
-  "webcatIsUnavailable": {
+  "WEBCAT_webcatIsUnavailable": {
     "message": "WEBCAT ei käytettävissä tällä sivustolla."
   }
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -47,7 +47,7 @@
       "48": "icons/light/webcat.SVG",
       "128": "icons/light/webcat.SVG"
     },
-    "default_title": "__MSG_webcatIsUnavailable__"
+    "default_title": "__MSG_WEBCAT_webcatIsUnavailable__"
   },
   "default_locale": "en"
 }

--- a/extension/pages/error.js
+++ b/extension/pages/error.js
@@ -5,7 +5,7 @@ document.addEventListener("DOMContentLoaded", () => {
         (child) => child.outerHTML,
       );
       const msg = browser.i18n.getMessage(
-        el.getAttribute("data-i18n"),
+        "WEBCAT_" + el.getAttribute("data-i18n"),
         substitutions,
       );
       if (msg === "") {
@@ -22,7 +22,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const host = params.get("host") || "";
   const file = params.get("file") || "";
 
-  setText("error-host", host || browser.i18n.getMessage("thisSite"));
+  setText("error-host", host || browser.i18n.getMessage("WEBCAT_thisSite"));
   setText("debug-code", code);
 
   if (file) {
@@ -36,8 +36,8 @@ document.addEventListener("DOMContentLoaded", () => {
     advancedPanel.hidden = !advancedPanel.hidden;
     advancedButton.setAttribute("aria-expanded", String(!advancedPanel.hidden));
     advancedButton.textContent = advancedPanel.hidden
-      ? browser.i18n.getMessage("advanced")
-      : browser.i18n.getMessage("hideAdvanced");
+      ? browser.i18n.getMessage("WEBCAT_advanced")
+      : browser.i18n.getMessage("WEBCAT_hideAdvanced");
   });
 
   // The error page took a history slot


### PR DESCRIPTION
This PR adds a `WEBCAT_` prefix to all i18n message names. That way we avoid collisions with existing strings in extensions that consume WEBCAT as a library.