### PR TITLE
Cancel cross-origin redirects of extension requests

### DIFF
--- a/extension/src/webcat/handler.ts
+++ b/extension/src/webcat/handler.ts
@@ -18,7 +18,12 @@ import { validateOrigin } from "./request";
 import { FRAME_TYPES } from "./resources";
 import { ResponseValidator } from "./response";
 import { errorpage, getErrorPageURL, setErrorIcon } from "./ui";
-import { getFQDN, isExtensionRequest, isNewerSemver } from "./utils";
+import {
+  getFQDN,
+  isExtensionRequest,
+  isNewerSemver,
+  isSameOriginURL,
+} from "./utils";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface WebcatRequestHandler extends RequestHandler {
@@ -185,8 +190,21 @@ export class WebcatRequestHandler extends RequestHandler {
     using blockingResponse = event.blockingResponse;
     const details = event.details as Stateful<HeadersReceivedDetails>;
 
-    // Skip non-enrolled and extension requests
-    if (!details.state || isExtensionRequest(details)) {
+    // Extension requests (such as bundle fetches) must never redirect
+    // cross-origin: cancel before the browser follows the Location header.
+    // Same-origin hops land back here, so the whole chain is checked.
+    if (isExtensionRequest(details)) {
+      const location = details.responseHeaders?.find(
+        (header) => header.name.toLowerCase() === "location",
+      )?.value;
+      if (location && !isSameOriginURL(location, details.url)) {
+        return blockingResponse.set({ cancel: true });
+      }
+      return;
+    }
+
+    // Skip non-enrolled requests
+    if (!details.state) {
       return;
     }
 

--- a/extension/src/webcat/response.ts
+++ b/extension/src/webcat/response.ts
@@ -25,6 +25,7 @@ import {
   arraysEqual,
   clearBrowserCaches,
   isNewerSemver,
+  isSameOriginURL,
   SHA256,
 } from "./utils";
 
@@ -49,16 +50,6 @@ function assertHeadersAvailable<T>(
 ): asserts details is HeadersReceivedDetails & T {
   if (!("responseHeaders" in details)) {
     throw new Error("response headers not available when expected");
-  }
-}
-
-export function isSameOriginURL(target: string, base: string) {
-  try {
-    const baseURL = new URL(base);
-    const targetURL = new URL(target, baseURL);
-    return targetURL.origin === baseURL.origin;
-  } catch {
-    return false;
   }
 }
 

--- a/extension/src/webcat/utils.ts
+++ b/extension/src/webcat/utils.ts
@@ -10,6 +10,16 @@ export function getFQDNSafe(url: string): string {
   return getFQDN(url);
 }
 
+export function isSameOriginURL(target: string, base: string) {
+  try {
+    const baseURL = new URL(base);
+    const targetURL = new URL(target, baseURL);
+    return targetURL.origin === baseURL.origin;
+  } catch {
+    return false;
+  }
+}
+
 export function isExtensionRequest(
   details: browser.webRequest._OnBeforeRequestDetails,
 ): boolean {

--- a/extension/tests/webcat/response.test.ts
+++ b/extension/tests/webcat/response.test.ts
@@ -22,8 +22,8 @@ import {
 } from "../../src/webcat/interfaces/errors";
 import { Stateful } from "../../src/webcat/interfaces/requeststate";
 import { BundleFetcher, OriginState } from "../../src/webcat/originstate";
-import { isSameOriginURL, ResponseValidator } from "../../src/webcat/response";
-import { SHA256 } from "../../src/webcat/utils";
+import { ResponseValidator } from "../../src/webcat/response";
+import { isSameOriginURL, SHA256 } from "../../src/webcat/utils";
 
 function makeDummyFetcher(): BundleFetcher {
   // base URL is irrelevant, fetch will never be awaited in these tests

--- a/test/tests.py
+++ b/test/tests.py
@@ -489,6 +489,37 @@ def test_version_refresh(browser: Browser, server: Server, update_server: Update
         browser.execute("location.reload()")
     assert expected in browser.execute("document.body.textContent")
 
+@pytest.mark.parametrize("browser", ["firefox"], indirect=True)
+@pytest.mark.parametrize("root, headers, hooks", [
+    ("cases/testapp", EXPECTED_CSP, FRAMEHOST_HOOK | {}),
+], indirect=["root"])
+def test_bundle_redirect(browser: Browser, server: Server, update_server: UpdateServer, addon_path, root, dnsnames, non_enrolled_dnsnames):
+    bundle_path = "/.well-known/webcat/bundle.json"
+    target = "/redirect-target-bundle.json"
+    with open(f"{root}{bundle_path}", "rb") as f:
+        bundle = f.read()
+    server.hooks[target] = Hook(bundle, type="application/json")
+    browser.install_extension(addon_path)
+    update_server.wait_for_update()
+
+    # A cross-origin redirect of the bundle fetch must be cancelled before it
+    # is followed: validation fails and the target is never requested
+    server.hooks[bundle_path] = Hook(b"", status=302, headers={
+        "Location": f"{server.url(non_enrolled_dnsnames[0])}{target}"})
+    served = Server._counts.get(target, 0)
+    with server.wait_for({"/", bundle_path}):
+        browser.navigate(server.url(dnsnames[0]))
+    res = browser.execute("document.body.textContent")
+    assert "ERR_WEBCAT_BUNDLE_FETCH_ERROR" in res
+    assert Server._counts.get(target, 0) == served, "cross-origin redirect target was fetched"
+
+    # A same-origin redirect is followed and the bundle validates normally
+    server.hooks[bundle_path] = Hook(b"", status=302, headers={
+        "Location": f"{server.url(dnsnames[1])}{target}"})
+    with server.wait_for(NON_FRAME_PATHS):
+        browser.navigate(server.url(dnsnames[1]))
+    assert "Hello!" in browser.execute("document.body.textContent")
+
 @pytest.mark.parametrize("browser", ["firefox", "tbb", "tbb_safer", "tbb_safest"], indirect=True)
 @pytest.mark.parametrize("root, headers, hooks, expected", [
     ("cases/testapp", EXPECTED_CSP | {


### PR DESCRIPTION
Fixes https://github.com/freedomofpress/webcat/issues/231. Sadly there's no way in the fetch API to get redirects step by step. There's either "accept" and verify the final destination or "reject" and get no info about it. So the workaround is to intercept our own requests and check that every hop is same-site. It also adds an integration test for it.