### PR TITLE
Fail closed on malformed enrollment/manifest/signatures

### DIFF
--- a/extension/src/webcat/canonicalize.ts
+++ b/extension/src/webcat/canonicalize.ts
@@ -1,5 +1,3 @@
-// From https://github.com/theupdateframework/tuf-js/blob/38d537ea883e8bb38ee6ab17b5f59ee479d0eab2/packages/canonical-json/lib/index.js
-
 const COMMA = ",";
 const COLON = ":";
 const LEFT_SQUARE_BRACKET = "[";
@@ -12,14 +10,17 @@ function canonicalizeString(string: string): string {
   return '"' + escapedString + '"';
 }
 
-// Recursively encodes the supplied object according to the canonical JSON form
-// as specified at http://wiki.laptop.org/go/Canonical_JSON. It's a restricted
+// Recursively encodes the supplied value as canonical JSON. It's a restricted
 // dialect of JSON in which keys are lexically sorted, floats are not allowed,
-// and only double quotes and backslashes are escaped.
-/**
- * JCS-canonicalizes a value. Returns null if it contains a value that cannot
- * be encoded (e.g. a non-integer number).
- */
+// and only double quotes and backslashes are escaped. Archived spec:
+// https://web.archive.org/web/20251209150702/http://wiki.laptop.org/go/Canonical_JSON
+//
+// tuf-js encodes it the same way, and webcat-infra-chain does too (via the
+// olpc-cjson crate), so the enrollment hashes match. Sigstore's canonical JSON
+// diverges, but only on floats and control characters, which should not appear
+// in what we hash.
+//
+// Returns null for anything it can't encode.
 export function canonicalize(object: unknown): string | null {
   const buffer: string[] = [];
   if (typeof object === "string") {

--- a/extension/src/webcat/canonicalize.ts
+++ b/extension/src/webcat/canonicalize.ts
@@ -16,7 +16,11 @@ function canonicalizeString(string: string): string {
 // as specified at http://wiki.laptop.org/go/Canonical_JSON. It's a restricted
 // dialect of JSON in which keys are lexically sorted, floats are not allowed,
 // and only double quotes and backslashes are escaped.
-export function canonicalize(object: object): string {
+/**
+ * JCS-canonicalizes a value. Returns null if it contains a value that cannot
+ * be encoded (e.g. a non-integer number).
+ */
+export function canonicalize(object: unknown): string | null {
   const buffer: string[] = [];
   if (typeof object === "string") {
     buffer.push(canonicalizeString(object));
@@ -29,32 +33,35 @@ export function canonicalize(object: object): string {
   } else if (Array.isArray(object)) {
     buffer.push(LEFT_SQUARE_BRACKET);
     let first = true;
-    object.forEach((element) => {
+    for (const element of object) {
       if (!first) {
         buffer.push(COMMA);
       }
       first = false;
-      buffer.push(canonicalize(element));
-    });
+      const encoded = canonicalize(element);
+      if (encoded === null) return null;
+      buffer.push(encoded);
+    }
     buffer.push(RIGHT_SQUARE_BRACKET);
   } else if (typeof object === "object") {
     buffer.push(LEFT_CURLY_BRACKET);
     let first = true;
-    Object.keys(object)
-      .sort()
-      .forEach((property) => {
-        if (!first) {
-          buffer.push(COMMA);
-        }
-        first = false;
-        buffer.push(canonicalizeString(property));
-        buffer.push(COLON);
-        // eslint-disable-next-line
-        buffer.push(canonicalize((object as any)[property])); // 'any' as a fallback
-      });
+    for (const property of Object.keys(object).sort()) {
+      if (!first) {
+        buffer.push(COMMA);
+      }
+      first = false;
+      buffer.push(canonicalizeString(property));
+      buffer.push(COLON);
+      const encoded = canonicalize(
+        (object as Record<string, unknown>)[property],
+      );
+      if (encoded === null) return null;
+      buffer.push(encoded);
+    }
     buffer.push(RIGHT_CURLY_BRACKET);
   } else {
-    throw new TypeError("cannot encode " + object);
+    return null;
   }
 
   return buffer.join("");

--- a/extension/src/webcat/originstate.ts
+++ b/extension/src/webcat/originstate.ts
@@ -197,6 +197,15 @@ export class OriginState implements IOriginState {
     );
   }
 
+  // Hashes an enrollment; null if it can't be canonicalized.
+  async #enrollmentHash(enrollment: Enrollment): Promise<Uint8Array | null> {
+    const canonicalized = canonicalize(enrollment);
+    if (canonicalized === null) {
+      return null;
+    }
+    return new Uint8Array(await SHA256(stringToUint8Array(canonicalized)));
+  }
+
   // This functiont ries to verify the enrollment information against the value in the local list
   // It will also return errors while fetching the bundles (though they are generated in awaitBundles)
   // and tell the next stages whether they should use the current or the previous bundle
@@ -218,11 +227,13 @@ export class OriginState implements IOriginState {
       enrollment = this.fetcher.current.value.enrollment;
     }
 
-    const canonicalized = stringToUint8Array(canonicalize(enrollment));
-    const canonicalized_hash = new Uint8Array(await SHA256(canonicalized));
+    // An enrollment that does not canonicalize counts as a non-match.
+    const canonicalized_hash = await this.#enrollmentHash(enrollment);
 
     // If it doesn't match, stop early
-    const match = arraysEqual(this.enrollment_hash, canonicalized_hash);
+    const match =
+      canonicalized_hash !== null &&
+      arraysEqual(this.enrollment_hash, canonicalized_hash);
     // In this case, we already tried both bundles and we should bail
     // Or we got direct enrollment passed, and we shpuldn't fallback automatically
     if (match) {
@@ -235,13 +246,13 @@ export class OriginState implements IOriginState {
       }
       enrollment = this.fetcher.previous.value.enrollment;
 
-      const canonicalized_prev = stringToUint8Array(canonicalize(enrollment));
-      const canonicalized_hash_prev = new Uint8Array(
-        await SHA256(canonicalized_prev),
-      );
+      const canonicalized_hash_prev = await this.#enrollmentHash(enrollment);
 
       // If this also fails it's fatal
-      if (!arraysEqual(this.enrollment_hash, canonicalized_hash_prev)) {
+      if (
+        canonicalized_hash_prev === null ||
+        !arraysEqual(this.enrollment_hash, canonicalized_hash_prev)
+      ) {
         return this.#fail(new WebcatError(WebcatErrorCode.Enrollment.MISMATCH));
       }
       this.#bundle = this.fetcher.previous.value;
@@ -291,11 +302,14 @@ export class OriginState implements IOriginState {
     // If enrollment information is passed from headers or another source, then we do not support
     // a fallback bundle at the moment
     if (!manifest || !signatures) {
-      // awaitBundle checks already that manifest exists
-      // eslint-disable-next-line
-      manifest = this.#bundle!.manifest;
-      // eslint-disable-next-line
-      signatures = this.#bundle!.signatures;
+      // The bundle may be absent (header enrollment with a failed fetch).
+      if (!this.#bundle) {
+        return this.#fail(
+          new WebcatError(WebcatErrorCode.Bundle.MANIFEST_MISSING),
+        );
+      }
+      manifest = this.#bundle.manifest;
+      signatures = this.#bundle.signatures;
     }
 
     let verify_result: WebcatError | number;

--- a/extension/src/webcat/validators.ts
+++ b/extension/src/webcat/validators.ts
@@ -528,7 +528,21 @@ export async function verifySigsumManifest(
   manifest: Manifest,
   signatures: SigsumSignatures,
 ): Promise<WebcatError | number> {
-  const canonicalized = stringToUint8Array(canonicalize(manifest));
+  // signatures must be a non-null object keyed by public key.
+  const untrusted: unknown = signatures;
+  if (
+    typeof untrusted !== "object" ||
+    untrusted === null ||
+    Array.isArray(untrusted)
+  ) {
+    return new WebcatError(WebcatErrorCode.Bundle.SIGNATURES_MISSING);
+  }
+  // canonicalize returns null for a manifest it cannot encode.
+  const canonical = canonicalize(manifest);
+  if (canonical === null) {
+    return new WebcatError(WebcatErrorCode.Manifest.VERIFY_FAILED);
+  }
+  const canonicalized = stringToUint8Array(canonical);
 
   // The purpose of cloning the original list of signers is to have logic to ensure
   // that each signers can at most sign once. Since we are dealing with a lot of
@@ -763,6 +777,18 @@ export async function verifySigstoreManifest(
 
   const policy = new AllOf(claimPolicies);
 
+  // signatures must be an array of bundles.
+  if (!Array.isArray(signatures)) {
+    return new WebcatError(WebcatErrorCode.Bundle.SIGNATURES_MISSING);
+  }
+
+  // canonicalize returns null for a manifest it cannot encode.
+  const canonical = canonicalize(manifest);
+  if (canonical === null) {
+    return new WebcatError(WebcatErrorCode.Manifest.VERIFY_FAILED);
+  }
+  const canonicalized = stringToUint8Array(canonical);
+
   let verified = false;
 
   // Does it make sense for this to be an array? Is there cases where the same manifest
@@ -772,7 +798,7 @@ export async function verifySigstoreManifest(
       verified = await verifier.verifyArtifactPolicy(
         policy,
         bundle,
-        stringToUint8Array(canonicalize(manifest)),
+        canonicalized,
       );
       if (verified) {
         break;

--- a/extension/tests/webcat/response.test.ts
+++ b/extension/tests/webcat/response.test.ts
@@ -141,6 +141,9 @@ async function computeEnrollmentHash(
   enrollment: Enrollment,
 ): Promise<Uint8Array> {
   const canonical = canonicalize(enrollment);
+  if (canonical === null) {
+    throw new Error("failed to canonicalize test enrollment");
+  }
   const bytes = stringToUint8Array(canonical);
   const digest = await SHA256(bytes);
   return digest instanceof Uint8Array ? digest : new Uint8Array(digest);


### PR DESCRIPTION
Attacker-controlled input reached three uncaught throws in the verification path, each of which let the request through unvalidated: `canonicalize()` could throw,  and in a few circumstances the bundle could be empty or the signatures could not be an array. 

Does not address directly https://github.com/freedomofpress/webcat/issues/176, which I'm gonna take next, but ensure there's less uncaught surface.