### PR TITLE
Fix FPO detection on Firefox (latest)

### DIFF
--- a/extension/src/webcat/handler.ts
+++ b/extension/src/webcat/handler.ts
@@ -318,7 +318,11 @@ export class WebcatRequestHandler extends RequestHandler {
    * Determines the first-party origin (FPO) for a given request
    */
   async #getFirstParty(details: BeforeRequestDetails): Promise<string> {
-    if (details.tabId === -1 || details.frameId === 0) {
+    if (
+      details.tabId === -1 ||
+      details.frameId === -1 ||
+      details.frameId === 0
+    ) {
       // This might be a SharedWorker or a ServiceWorker,
       // or a Worker request affected by https://bugzilla.mozilla.org/show_bug.cgi?id=2048884
       for (const url of [details.url, details.documentUrl, details.originUrl]) {
@@ -338,7 +342,7 @@ export class WebcatRequestHandler extends RequestHandler {
         details.frameAncestors[details.frameAncestors.length - 1].url,
       ).origin;
     }
-    if (details.frameId !== 0) {
+    if (details.frameId !== 0 && details.frameId !== -1) {
       // Subresource of a Worker in a frame; no frameAncestors available; check the tab
       const frames = await browser.webNavigation.getAllFrames({
         tabId: details.tabId,


### PR DESCRIPTION
[Tests were failing](https://github.com/freedomofpress/webcat/actions/runs/33865837057/job/101000393104?pr=249) on Firefox (latest) because first-party origins were no longer being correctly detected: Firefox now reports frameIds of non-framed requests as `-1` instead of `0`, which broke the detection logic. This PR fixes that while maintaining compatibility with ESR versions that still report incorrect frameIds.